### PR TITLE
Only ignore `sea` bit for `wet|dry` flag

### DIFF
--- a/products/ga_ls8c_wofs_2.yaml
+++ b/products/ga_ls8c_wofs_2.yaml
@@ -14,12 +14,12 @@ measurements:
         nodata: 1
         flags_definition:
             dry:
-                bits: [7, 6, 5, 1, 0]
+                bits: [7, 6, 5, 4, 3, 1, 0]
                 values:
                     0: true
                 description: 'Clear and dry'
             wet:
-                bits: [7, 6, 5, 1, 0]
+                bits: [7, 6, 5, 4, 3, 1, 0]
                 values:
                     128: true
                 description: 'Clear and Wet'

--- a/products/ls_usgs_wofs_scene.yaml
+++ b/products/ls_usgs_wofs_scene.yaml
@@ -14,12 +14,12 @@ measurements:
         nodata: 1
         flags_definition:
             dry:
-                bits: [7, 6, 5, 1, 0]
+                bits: [7, 6, 5, 4, 3, 1, 0]
                 values:
                     0: true
                 description: 'Clear and dry'
             wet:
-                bits: [7, 6, 5, 1, 0]
+                bits: [7, 6, 5, 4, 3, 1, 0]
                 values:
                     128: true
                 description: 'Clear and Wet'


### PR DESCRIPTION
Adding checks for bits 3,4 terrain shadow and high slope.

Make `wet|dry` flags match behaviour of wofs stats code here:

https://github.com/GeoscienceAustralia/wofs/blob/8f4d6da9c00cb21b21752bc91814995c05e3980f/wofs-summary/simple.py#L99-L116

That code checks all quality bits except for `sea` (bit `2`).