### PR TITLE
Change alias for NPV in FC

### DIFF
--- a/products/ga_ls8c_fc_2.yaml
+++ b/products/ga_ls8c_fc_2.yaml
@@ -23,7 +23,7 @@ measurements:
     units: percent
   - name: npv
     aliases:
-      - dead_veg
+      - dry_veg
     dtype: int16
     nodata: -1
     units: percent


### PR DESCRIPTION
On the advice of Leo, this should never have been "dead_veg". We have verified this incorrect alias came from the original FC code.