### PR TITLE
Remove broken CRS

### DIFF
--- a/services/ows_cfg.py
+++ b/services/ows_cfg.py
@@ -2193,11 +2193,6 @@ ows_cfg = {
                 "horizontal_coord": "x",
                 "vertical_coord": "y",
             },
-            "EPSG:102022": {  # Deprecated, but it's requred as it was update_ranges'd against
-                "geographic": False,
-                "horizontal_coord": "x",
-                "vertical_coord": "y",
-            },
             "EPSG:4326": {  # WGS-84
                 "geographic": True,
                 "vertical_coord_first": True


### PR DESCRIPTION
as it's not a valid CRS it stops update ranges from running correctly with the following error: 

`datacube.utils.geometry._base.InvalidCRSError: Not a valid CRS: 'EPSG:102022'`