### PR TITLE
add tileErrorThresholdBeforeDisabling parameter to catalog items

### DIFF
--- a/terria/africa.json
+++ b/terria/africa.json
@@ -34,6 +34,7 @@
                            "linkedWcsUrl": "https://ows.digitalearth.africa/",
                            "linkedWcsCoverage": "s2_l2a",
                            "ignoreUnknownTileErrors": true,
+                           "tileErrorThresholdBeforeDisabling": 100000,
                            "opacity": 1,
                            "featureTimesProperty": "data_available_for_dates",
                            "featureInfoTemplate": {
@@ -56,6 +57,7 @@
                            "linkedWcsUrl": "https://ows.digitalearth.africa/",
                            "linkedWcsCoverage": "ls5_usgs_sr_scene",
                            "ignoreUnknownTileErrors": true,
+                           "tileErrorThresholdBeforeDisabling": 100000,
                            "opacity": 1,
                            "featureTimesProperty": "data_available_for_dates",
                            "featureInfoTemplate": {
@@ -78,6 +80,7 @@
                            "linkedWcsUrl": "https://ows.digitalearth.africa/",
                            "linkedWcsCoverage": "ls7_usgs_sr_scene",
                            "ignoreUnknownTileErrors": true,
+                           "tileErrorThresholdBeforeDisabling": 100000,
                            "opacity": 1,
                            "featureTimesProperty": "data_available_for_dates",
                            "featureInfoTemplate": {
@@ -100,6 +103,7 @@
                            "linkedWcsUrl": "https://ows.digitalearth.africa/",
                            "linkedWcsCoverage": "ls8_usgs_sr_scene",
                            "ignoreUnknownTileErrors": true,
+                           "tileErrorThresholdBeforeDisabling": 100000,
                            "opacity": 1,
                            "featureTimesProperty": "data_available_for_dates",
                            "featureInfoTemplate": {
@@ -128,12 +132,13 @@
                            "url": "https://ows.digitalearth.africa/",
                            "linkedWcsUrl": "https://ows.digitalearth.africa/",
                            "linkedWcsCoverage": "ga_ls8c_gm_2_annual",
+                           "tileErrorThresholdBeforeDisabling": 100000,
                            "ignoreUnknownTileErrors": true,
                            "opacity": 1,
                            "featureTimesProperty": "data_available_for_dates"
                         }
                      ]
-                  },
+                  }
                ]
             },
             {
@@ -148,6 +153,7 @@
                      "url": "https://ows.digitalearth.africa/",
                      "linkedWcsUrl": "https://ows.digitalearth.africa/",
                      "linkedWcsCoverage": "alos_palsar_mosaic",
+                     "tileErrorThresholdBeforeDisabling": 100000,
                      "ignoreUnknownTileErrors": true,
                      "opacity": 1,
                      "featureTimesProperty": "data_available_for_dates",
@@ -184,6 +190,7 @@
                      "linkedWcsUrl": "https://ows.digitalearth.africa/",
                      "linkedWcsCoverage": "ls_usgs_wofs_scene",
                      "ignoreUnknownTileErrors": true,
+                     "tileErrorThresholdBeforeDisabling": 100000,
                      "opacity": 1,
                      "featureTimesProperty": "data_available_for_dates"
                   },
@@ -195,6 +202,7 @@
                      "linkedWcsUrl": "https://ows.digitalearth.africa/",
                      "linkedWcsCoverage": "wofs_annual_summary_frequency",
                      "ignoreUnknownTileErrors": true,
+                     "tileErrorThresholdBeforeDisabling": 100000,
                      "opacity": 1,
                      "featureTimesProperty": "data_available_for_dates"
                   },
@@ -242,6 +250,7 @@
                      "linkedWcsUrl": "https://ows.digitalearth.africa/",
                      "linkedWcsCoverage": "ga_ls8c_wofs_2",
                      "ignoreUnknownTileErrors": true,
+                     "tileErrorThresholdBeforeDisabling": 100000,
                      "opacity": 1
                   },
                   {
@@ -252,6 +261,7 @@
                      "linkedWcsUrl": "https://ows.digitalearth.africa/",
                      "linkedWcsCoverage": "wofs_2_annual_summary_frequency",
                      "ignoreUnknownTileErrors": true,
+                     "tileErrorThresholdBeforeDisabling": 100000,
                      "opacity": 1,
                      "featureTimesProperty": "data_available_for_dates"
                   },
@@ -263,6 +273,7 @@
                      "linkedWcsUrl": "https://ows.digitalearth.africa/",
                      "linkedWcsCoverage": "wofs_2_summary_frequency",
                      "ignoreUnknownTileErrors": true,
+                     "tileErrorThresholdBeforeDisabling": 100000,
                      "opacity": 1
                   },
                   {
@@ -278,6 +289,7 @@
                            "linkedWcsUrl": "https://ows.digitalearth.africa/",
                            "linkedWcsCoverage": "wofs_2_annual_summary_wet",
                            "ignoreUnknownTileErrors": true,
+                           "tileErrorThresholdBeforeDisabling": 100000,
                            "opacity": 1,
                            "featureTimesProperty": "data_available_for_dates"
                         },
@@ -289,6 +301,7 @@
                            "linkedWcsUrl": "https://ows.digitalearth.africa/",
                            "linkedWcsCoverage": "wofs_2_annual_summary_clear",
                            "ignoreUnknownTileErrors": true,
+                           "tileErrorThresholdBeforeDisabling": 100000,
                            "opacity": 1,
                            "featureTimesProperty": "data_available_for_dates"
                         }
@@ -306,6 +319,7 @@
                            "url": "https://ows.digitalearth.africa/",
                            "linkedWcsUrl": "https://ows.digitalearth.africa/",
                            "linkedWcsCoverage": "wofs_2_summary_wet",
+                           "tileErrorThresholdBeforeDisabling": 100000,
                            "ignoreUnknownTileErrors": true,
                            "opacity": 1
                         },
@@ -317,6 +331,7 @@
                            "linkedWcsUrl": "https://ows.digitalearth.africa/",
                            "linkedWcsCoverage": "wofs_2_summary_clear",
                            "ignoreUnknownTileErrors": true,
+                           "tileErrorThresholdBeforeDisabling": 100000,
                            "opacity": 1
                         }
                      ]
@@ -338,6 +353,7 @@
                "linkedWcsUrl": "https://ows.digitalearth.africa/",
                "linkedWcsCoverage": "ls_usgs_fc_scene",
                "ignoreUnknownTileErrors": true,
+               "tileErrorThresholdBeforeDisabling": 100000,
                "opacity": 1,
                "featureTimesProperty": "data_available_for_dates"
             }
@@ -356,6 +372,7 @@
                "linkedWcsUrl": "https://ows.digitalearth.africa/",
                "linkedWcsCoverage": "srtm",
                "ignoreUnknownTileErrors": true,
+               "tileErrorThresholdBeforeDisabling": 100000,
                "opacity": 1
             }
          ]


### PR DESCRIPTION
This PR sets the 
`tileErrorThresholdBeforeDisabling` parameter on catalog items for DE-Africa map to a higher than default value, this helps to mitigate the Terria Error box which gets thrown because of SPDY errors in the 2D view.

To test it out visit http://de-africa-20200612t091417.terria.io/#clean and you can drop the revised africa.json on it.