### PR TITLE
Add ga_s2_clear_pixel_count product definintion

### DIFF
--- a/products/ga_s2_clear_pixel_count.yml
+++ b/products/ga_s2_clear_pixel_count.yml
@@ -1,0 +1,28 @@
+name: ga_s2_clear_pixel_count
+description: Clear Pixel Count S2A/B
+
+metadata_type: eo3
+
+metadata:
+  product:
+    name: ga_s2_clear_pixel_count
+
+storage:
+    crs: EPSG:6933
+    resolution:
+      x: 20
+      y: -20
+    tile_size:
+      x: 96000
+      y: 96000
+
+measurements:
+- name: total
+  dtype: uint16
+  nodata: 0
+  units: '1'
+
+- name: clear
+  dtype: uint16
+  nodata: 0
+  units: '1'


### PR DESCRIPTION
Product spec for clear pixel count product, this was tested in collection2 db.
Data for it is currently here:

- `s3://deafrica-stats-processing/ga_s2_clear_pixel_count/v0.0.0/`
- https://s3.console.aws.amazon.com/s3/buckets/deafrica-stats-processing/ga_s2_clear_pixel_count/v0.0.0/?region=us-west-2&tab=overview

