### PR TITLE
Add extra clear bands to clear pixel count product

### DIFF
--- a/products/ga_s2_clear_pixel_count.yml
+++ b/products/ga_s2_clear_pixel_count.yml
@@ -26,3 +26,13 @@ measurements:
   dtype: uint16
   nodata: 0
   units: '1'
+
+- name: clear_0_5
+  dtype: uint16
+  nodata: 0
+  units: '1'
+
+- name: clear_2_5
+  dtype: uint16
+  nodata: 0
+  units: '1'


### PR DESCRIPTION
We now compute clear mask with 2 pre-processing options
- Buffer with 5 pixels (`clear_0_5`)
- Shrink away small clouds (R=2) then buffer with 5 pixels (`clear_2_5`)