### PR TITLE
Split LS SR and ST

### DIFF
--- a/products/ls5_sr.odc-product.yaml
+++ b/products/ls5_sr.odc-product.yaml
@@ -1,104 +1,56 @@
 ---
-name: ls5_c2l2
-description: USGS Level 2 Collection 2 Landsat
+name: ls5_sr
+description: USGS Landsat 5 Collection 2 Level-2 Surface Reflectance
 metadata_type: eo3
 
 license: CC-BY-4.0
 
 metadata:
   product:
-    name: ls5_c2l2
+    name: ls5_sr
 
 measurements:
   - name: SR_B1
     dtype: "uint16"
     units: "1"
     nodata: 0
-    aliases: [B1, band_1, blue]
+    aliases: [band_1, blue]
 
   - name: SR_B2
     dtype: "uint16"
     units: "1"
     nodata: 0
-    aliases: [B2, band_2, green]
+    aliases: [band_2, green]
 
   - name: SR_B3
     dtype: "uint16"
     units: "1"
     nodata: 0
-    aliases: [B3, band_3, red]
+    aliases: [band_3, red]
 
   - name: SR_B4
     dtype: "uint16"
     units: "1"
     nodata: 0
-    aliases: [B4, band_4, nir]
+    aliases: [band_4, nir]
 
   - name: SR_B5
     dtype: "uint16"
     units: "1"
     nodata: 0
-    aliases: [B5, band_5, swir_1]
+    aliases: [band_5, swir_1]
 
   - name: SR_B7
     dtype: "uint16"
     units: "1"
     nodata: 0
-    aliases: [B7, band_7, swir_2]
-
-  - name: ST_B6
-    dtype: "uint16"
-    units: "Kelvin"
-    nodata: 0
-    aliases: [B6, band_6, surface_temperature, land_surface_temperature]
-
-  - name: ST_TRAD
-    dtype: "int16"
-    units: "W/(m2.sr.μm)"
-    nodata: -9999
-    aliases: [st_trad, thermal_radiance]
-
-  - name: ST_URAD
-    dtype: "int16"
-    units: "W/(m2.sr.μm)"
-    nodata: -9999
-    aliases: [st_urad, upwell_radiance]
-
-  - name: ST_DRAD
-    dtype: "int16"
-    units: "W/(m2.sr.μm)"
-    nodata: -9999
-    aliases: [st_drad, downwell_radiance]
-
-  - name: ST_ATRAN
-    dtype: "int16"
-    units: "1"
-    nodata: -9999
-    aliases: [st_atran, atmospheric_transmittance]
-
-  - name: ST_EMIS
-    dtype: "int16"
-    units: "1"
-    nodata: -9999
-    aliases: [st_emis, emissivity]
-
-  - name: ST_EMSD
-    dtype: "int16"
-    units: "1"
-    nodata: -9999
-    aliases: [st_emsd, emissivity_stddev, emissivity_standard_deviation]
-
-  - name: ST_CDIST
-    dtype: "int16"
-    units: "Kilometers"
-    nodata: -9999
-    aliases: [st_cdist, cloud_distance]
+    aliases: [band_7, swir_2]
 
   - name: QA_PIXEL
     dtype: "uint16"
     units: "bit_index"
     nodata: 1
-    aliases: [quality_pixel, pixel_quality, pq]
+    aliases: [pixel_quality]
     flags_definition:
       nodata:
         bits: 0
@@ -161,7 +113,7 @@ measurements:
     dtype: "uint16"
     units: "bit_index"
     nodata: 0
-    aliases: [quality_radiometric_saturation, radiometric_saturation]
+    aliases: [radiometric_saturation]
     flags_definition:
       band_1_saturation:
         bits: 0
@@ -198,23 +150,58 @@ measurements:
         values:
           0: false
           1: true
+      blue_saturation:
+        bits: 0
+        values:
+          0: false
+          1: true
+      green_saturation:
+        bits: 1
+        values:
+          0: false
+          1: true
+      red_saturation:
+        bits: 2
+        values:
+          0: false
+          1: true
+      nir_saturation:
+        bits: 3
+        values:
+          0: false
+          1: true
+      swir_1_saturation:
+        bits: 4
+        values:
+          0: false
+          1: true
+      tir_saturation:
+        bits: 5
+        values:
+          0: false
+          1: true
+      swir_2_saturation:
+        bits: 6
+        values:
+          0: false
+          1: true
       dropped_pixel:
         bits: 9
         values:
-          0: true
-          1: false
+          0: false
+          1: true
 
   - name: SR_ATMOS_OPACITY
     dtype: "int16"
     units: "1"
     nodata: -9999
-    aliases: [atmos_op, atmospheric_opacity]
+    aliases: [atmospheric_opacity]
 
   - name: SR_CLOUD_QA
     dtype: "uint8"
     units: "bit_index"
     nodata: 0
-    aliases: [cloud_qa, qa_cloud]
+    aliases: [cloud_qa]
     flags_definition:
       dark_dense_vegetation:
         bits: 0
@@ -246,9 +233,3 @@ measurements:
         values:
           0: false
           1: true
-
-  - name: ST_QA
-    dtype: "int16"
-    units: "Kelvin"
-    nodata: -9999
-    aliases: [quality_surface_temperature, surface_temperature_quality]

--- a/products/ls5_sr.odc-product.yaml
+++ b/products/ls5_sr.odc-product.yaml
@@ -50,7 +50,7 @@ measurements:
     dtype: "uint16"
     units: "bit_index"
     nodata: 1
-    aliases: [pixel_quality]
+    aliases: [pq, pixel_quality]
     flags_definition:
       nodata:
         bits: 0
@@ -113,7 +113,7 @@ measurements:
     dtype: "uint16"
     units: "bit_index"
     nodata: 0
-    aliases: [radiometric_saturation]
+    aliases: [radsat, radiometric_saturation]
     flags_definition:
       band_1_saturation:
         bits: 0
@@ -195,7 +195,7 @@ measurements:
     dtype: "int16"
     units: "1"
     nodata: -9999
-    aliases: [atmospheric_opacity]
+    aliases: [atmos_opacity]
 
   - name: SR_CLOUD_QA
     dtype: "uint8"

--- a/products/ls5_st.odc-product.yaml
+++ b/products/ls5_st.odc-product.yaml
@@ -14,55 +14,55 @@ measurements:
     dtype: "uint16"
     units: "Kelvin"
     nodata: 0
-    aliases: [band_6, surface_temperature]
+    aliases: [band_6, st, surface_temperature]
 
   - name: ST_TRAD
     dtype: "int16"
     units: "W/(m2.sr.μm)"
     nodata: -9999
-    aliases: [thermal_radiance]
+    aliases: [trad, thermal_radiance]
 
   - name: ST_URAD
     dtype: "int16"
     units: "W/(m2.sr.μm)"
     nodata: -9999
-    aliases: [upwell_radiance]
+    aliases: [urad, upwell_radiance]
 
   - name: ST_DRAD
     dtype: "int16"
     units: "W/(m2.sr.μm)"
     nodata: -9999
-    aliases: [downwell_radiance]
+    aliases: [drad, downwell_radiance]
 
   - name: ST_ATRAN
     dtype: "int16"
     units: "1"
     nodata: -9999
-    aliases: [atmospheric_transmittance]
+    aliases: [atran, atmospheric_transmittance]
 
   - name: ST_EMIS
     dtype: "int16"
     units: "1"
     nodata: -9999
-    aliases: [emissivity]
+    aliases: [emis, emissivity]
 
   - name: ST_EMSD
     dtype: "int16"
     units: "1"
     nodata: -9999
-    aliases: [emissivity_stddev]
+    aliases: [emsd, emissivity_stddev]
 
   - name: ST_CDIST
     dtype: "int16"
     units: "Kilometers"
     nodata: -9999
-    aliases: [cloud_distance]
+    aliases: [cdist, cloud_distance]
 
   - name: QA_PIXEL
     dtype: "uint16"
     units: "bit_index"
     nodata: 1
-    aliases: [pixel_quality]
+    aliases: [pq, pixel_quality]
     flags_definition:
       nodata:
         bits: 0
@@ -125,7 +125,7 @@ measurements:
     dtype: "uint16"
     units: "bit_index"
     nodata: 0
-    aliases: [radiometric_saturation]
+    aliases: [radsat, radiometric_saturation]
     flags_definition:
       band_1_saturation:
         bits: 0
@@ -207,4 +207,4 @@ measurements:
     dtype: "int16"
     units: "Kelvin"
     nodata: -9999
-    aliases: [surface_temperature_quality]
+    aliases: [st_qa, surface_temperature_quality]

--- a/products/ls5_st.odc-product.yaml
+++ b/products/ls5_st.odc-product.yaml
@@ -1,110 +1,68 @@
 ---
-name: ls8_c2l2
-description: USGS Level 2 Collection 2 Landsat
+name: ls5_st
+description: USGS Landsat 5 Collection 2 Level-2 Surface Temperature
 metadata_type: eo3
 
 license: CC-BY-4.0
 
 metadata:
   product:
-    name: ls8_c2l2
+    name: ls5_st
 
 measurements:
-  - name: SR_B1
-    units: "1"
+  - name: ST_B6
     dtype: "uint16"
-    nodata: 0
-    aliases: [B1, band_1, coastal_aerosol]
-
-  - name: SR_B2
-    units: "1"
-    dtype: "uint16"
-    nodata: 0
-    aliases: [B2, band_2, blue]
-
-  - name: SR_B3
-    units: "1"
-    dtype: "uint16"
-    nodata: 0
-    aliases: [B3, band_3, green]
-
-  - name: SR_B4
-    units: "1"
-    dtype: "uint16"
-    nodata: 0
-    aliases: [B4, band_4, red]
-
-  - name: SR_B5
-    units: "1"
-    dtype: "uint16"
-    nodata: 0
-    aliases: [B5, band_5, nir]
-
-  - name: SR_B6
-    units: "1"
-    dtype: "uint16"
-    nodata: 0
-    aliases: [B6, band_6, swir_1]
-
-  - name: SR_B7
-    units: "1"
-    dtype: "uint16"
-    nodata: 0
-    aliases: [B7, band_7, swir_2]
-
-  - name: ST_B10
     units: "Kelvin"
-    dtype: "uint16"
     nodata: 0
-    aliases: [B10, band_10, surface_temperature, land_surface_temperature]
+    aliases: [band_6, surface_temperature]
 
   - name: ST_TRAD
     dtype: "int16"
     units: "W/(m2.sr.μm)"
     nodata: -9999
-    aliases: [st_trad, thermal_radiance]
+    aliases: [thermal_radiance]
 
   - name: ST_URAD
     dtype: "int16"
     units: "W/(m2.sr.μm)"
     nodata: -9999
-    aliases: [st_urad, upwell_radiance]
+    aliases: [upwell_radiance]
 
   - name: ST_DRAD
     dtype: "int16"
     units: "W/(m2.sr.μm)"
     nodata: -9999
-    aliases: [st_drad, downwell_radiance]
+    aliases: [downwell_radiance]
 
   - name: ST_ATRAN
     dtype: "int16"
     units: "1"
     nodata: -9999
-    aliases: [st_atran, atmospheric_transmittance]
+    aliases: [atmospheric_transmittance]
 
   - name: ST_EMIS
     dtype: "int16"
     units: "1"
     nodata: -9999
-    aliases: [st_emis, emissivity]
+    aliases: [emissivity]
 
   - name: ST_EMSD
     dtype: "int16"
     units: "1"
     nodata: -9999
-    aliases: [st_emsd, emissivity_stddev, emissivity_standard_deviation]
+    aliases: [emissivity_stddev]
 
   - name: ST_CDIST
     dtype: "int16"
     units: "Kilometers"
     nodata: -9999
-    aliases: [st_cdist, cloud_distance]
+    aliases: [cloud_distance]
 
   - name: QA_PIXEL
     dtype: "uint16"
     units: "bit_index"
     nodata: 1
-    aliases: [quality_pixel, pixel_quality, pq]
+    aliases: [pixel_quality]
     flags_definition:
       nodata:
         bits: 0
@@ -116,11 +74,6 @@ measurements:
         values:
           0: not_dilated
           1: dilated
-      cirrus:
-        bits: 2
-        values:
-          0: not_high_confidence
-          1: high_confidence
       cloud:
         bits: 3
         values:
@@ -167,19 +120,12 @@ measurements:
           1: low
           2: reserved
           3: high
-      cirrus_confidence:
-        bits: [14, 15]
-        values:
-          0: none
-          1: low
-          2: reserved
-          3: high
 
   - name: QA_RADSAT
     dtype: "uint16"
     units: "bit_index"
     nodata: 0
-    aliases: [quality_radiometric_saturation, radiometric_saturation]
+    aliases: [radiometric_saturation]
     flags_definition:
       band_1_saturation:
         bits: 0
@@ -216,48 +162,49 @@ measurements:
         values:
           0: false
           1: true
-      terrain_occlusion:
-        bits: 11
-        values:
-          0: false
-          1: true
-
-  - name: SR_QA_AEROSOL
-    dtype: "uint8"
-    units: "bit_index"
-    nodata: 1
-    aliases: [aerosol_qa, qa_aerosol]
-    flags_definition:
-      nodata:
+      blue_saturation:
         bits: 0
         values:
           0: false
           1: true
-      valid_aerosol_retrieval:
+      green_saturation:
         bits: 1
         values:
           0: false
           1: true
-      water:
+      red_saturation:
         bits: 2
         values:
           0: false
           1: true
-      interpolated_aerosol:
+      nir_saturation:
+        bits: 3
+        values:
+          0: false
+          1: true
+      swir_1_saturation:
+        bits: 4
+        values:
+          0: false
+          1: true
+      tir_saturation:
         bits: 5
         values:
           0: false
           1: true
-      aerosol_level:
-        bits: [6, 7]
+      swir_2_saturation:
+        bits: 6
         values:
-          0: climatology
-          1: low
-          2: medium
-          3: high
+          0: false
+          1: true
+      dropped_pixel:
+        bits: 9
+        values:
+          0: false
+          1: true
 
   - name: ST_QA
     dtype: "int16"
     units: "Kelvin"
     nodata: -9999
-    aliases: [quality_surface_temperature, surface_temperature_quality]
+    aliases: [surface_temperature_quality]

--- a/products/ls7_sr.odc-product.yaml
+++ b/products/ls7_sr.odc-product.yaml
@@ -50,7 +50,7 @@ measurements:
     dtype: "uint16"
     units: "bit_index"
     nodata: 1
-    aliases: [pixel_quality]
+    aliases: [pq, pixel_quality]
     flags_definition:
       nodata:
         bits: 0
@@ -113,7 +113,7 @@ measurements:
     dtype: "uint16"
     units: "bit_index"
     nodata: 0
-    aliases: [radiometric_saturation]
+    aliases: [radsat, radiometric_saturation]
     flags_definition:
       band_1_saturation:
         bits: 0
@@ -205,7 +205,7 @@ measurements:
     dtype: "int16"
     units: "1"
     nodata: -9999
-    aliases: [atmospheric_opacity]
+    aliases: [atmos_opacity]
 
   - name: SR_CLOUD_QA
     dtype: "uint8"

--- a/products/ls7_sr.odc-product.yaml
+++ b/products/ls7_sr.odc-product.yaml
@@ -1,0 +1,245 @@
+---
+name: ls7_sr
+description: USGS Landsat 7 Collection 2 Level-2 Surface Reflectance
+metadata_type: eo3
+
+license: CC-BY-4.0
+
+metadata:
+  product:
+    name: ls7_sr
+
+measurements:
+  - name: SR_B1
+    dtype: "uint16"
+    units: "1"
+    nodata: 0
+    aliases: [band_1, blue]
+
+  - name: SR_B2
+    dtype: "uint16"
+    units: "1"
+    nodata: 0
+    aliases: [band_2, green]
+
+  - name: SR_B3
+    dtype: "uint16"
+    units: "1"
+    nodata: 0
+    aliases: [band_3, red]
+
+  - name: SR_B4
+    dtype: "uint16"
+    units: "1"
+    nodata: 0
+    aliases: [band_4, nir]
+
+  - name: SR_B5
+    dtype: "uint16"
+    units: "1"
+    nodata: 0
+    aliases: [band_5, swir_1]
+
+  - name: SR_B7
+    dtype: "uint16"
+    units: "1"
+    nodata: 0
+    aliases: [band_7, swir_2]
+
+  - name: QA_PIXEL
+    dtype: "uint16"
+    units: "bit_index"
+    nodata: 1
+    aliases: [pixel_quality]
+    flags_definition:
+      nodata:
+        bits: 0
+        values:
+          0: false
+          1: true
+      dilated_cloud:
+        bits: 1
+        values:
+          0: not_dilated
+          1: dilated
+      cloud:
+        bits: 3
+        values:
+          0: not_high_confidence
+          1: high_confidence
+      cloud_shadow:
+        bits: 4
+        values:
+          0: not_high_confidence
+          1: high_confidence
+      snow:
+        bits: 5
+        values:
+          0: not_high_confidence
+          1: high_confidence
+      clear:
+        bits: 6
+        values:
+          0: false
+          1: true
+      water:
+        bits: 7
+        values:
+          0: land_or_cloud
+          1: water
+      cloud_confidence:
+        bits: [8, 9]
+        values:
+          0: none
+          1: low
+          2: medium
+          3: high
+      cloud_shadow_confidence:
+        bits: [10, 11]
+        values:
+          0: none
+          1: low
+          2: reserved
+          3: high
+      snow_ice_confidence:
+        bits: [12, 13]
+        values:
+          0: none
+          1: low
+          2: reserved
+          3: high
+
+  - name: QA_RADSAT
+    dtype: "uint16"
+    units: "bit_index"
+    nodata: 0
+    aliases: [radiometric_saturation]
+    flags_definition:
+      band_1_saturation:
+        bits: 0
+        values:
+          0: false
+          1: true
+      band_2_saturation:
+        bits: 1
+        values:
+          0: false
+          1: true
+      band_3_saturation:
+        bits: 2
+        values:
+          0: false
+          1: true
+      band_4_saturation:
+        bits: 3
+        values:
+          0: false
+          1: true
+      band_5_saturation:
+        bits: 4
+        values:
+          0: false
+          1: true
+      band_6L_saturation:
+        bits: 5
+        values:
+          0: false
+          1: true
+      band_7_saturation:
+        bits: 6
+        values:
+          0: false
+          1: true
+      band_6H_saturation:
+        bits: 8
+        values:
+          0: false
+          1: true
+      blue_saturation:
+        bits: 0
+        values:
+          0: false
+          1: true
+      green_saturation:
+        bits: 1
+        values:
+          0: false
+          1: true
+      red_saturation:
+        bits: 2
+        values:
+          0: false
+          1: true
+      nir_saturation:
+        bits: 3
+        values:
+          0: false
+          1: true
+      swir_1_saturation:
+        bits: 4
+        values:
+          0: false
+          1: true
+      tir_l_saturation:
+        bits: 5
+        values:
+          0: false
+          1: true
+      tir_h_saturation:
+        bits: 8
+        values:
+          0: false
+          1: true
+      swir_2_saturation:
+        bits: 6
+        values:
+          0: false
+          1: true
+      dropped_pixel:
+        bits: 9
+        values:
+          0: false
+          1: true
+
+  - name: SR_ATMOS_OPACITY
+    dtype: "int16"
+    units: "1"
+    nodata: -9999
+    aliases: [atmospheric_opacity]
+
+  - name: SR_CLOUD_QA
+    dtype: "uint8"
+    units: "bit_index"
+    nodata: 0
+    aliases: [cloud_qa]
+    flags_definition:
+      dark_dense_vegetation:
+        bits: 0
+        values:
+          0: false
+          1: true
+      cloud:
+        bits: 1
+        values:
+          0: false
+          1: true
+      cloud_shadow:
+        bits: 2
+        values:
+          0: false
+          1: true
+      adjacent_to_cloud:
+        bits: 3
+        values:
+          0: false
+          1: true
+      snow:
+        bits: 4
+        values:
+          0: false
+          1: true
+      water:
+        bits: 5
+        values:
+          0: false
+          1: true

--- a/products/ls7_st.odc-product.yaml
+++ b/products/ls7_st.odc-product.yaml
@@ -14,55 +14,55 @@ measurements:
     dtype: "uint16"
     units: "Kelvin"
     nodata: 0
-    aliases: [band_6, surface_temperature]
+    aliases: [band_6, st, surface_temperature]
 
   - name: ST_TRAD
     dtype: "int16"
     units: "W/(m2.sr.μm)"
     nodata: -9999
-    aliases: [thermal_radiance]
+    aliases: [trad, thermal_radiance]
 
   - name: ST_URAD
     dtype: "int16"
     units: "W/(m2.sr.μm)"
     nodata: -9999
-    aliases: [upwell_radiance]
+    aliases: [urad, upwell_radiance]
 
   - name: ST_DRAD
     dtype: "int16"
     units: "W/(m2.sr.μm)"
     nodata: -9999
-    aliases: [downwell_radiance]
+    aliases: [drad, downwell_radiance]
 
   - name: ST_ATRAN
     dtype: "int16"
     units: "1"
     nodata: -9999
-    aliases: [atmospheric_transmittance]
+    aliases: [atran, atmospheric_transmittance]
 
   - name: ST_EMIS
     dtype: "int16"
     units: "1"
     nodata: -9999
-    aliases: [emissivity]
+    aliases: [emis, emissivity]
 
   - name: ST_EMSD
     dtype: "int16"
     units: "1"
     nodata: -9999
-    aliases: [emissivity_stddev]
+    aliases: [emsd, emissivity_stddev]
 
   - name: ST_CDIST
     dtype: "int16"
     units: "Kilometers"
     nodata: -9999
-    aliases: [cloud_distance]
+    aliases: [cdist, cloud_distance]
 
   - name: QA_PIXEL
     dtype: "uint16"
     units: "bit_index"
     nodata: 1
-    aliases: [pixel_quality]
+    aliases: [pq, pixel_quality]
     flags_definition:
       nodata:
         bits: 0
@@ -125,7 +125,7 @@ measurements:
     dtype: "uint16"
     units: "bit_index"
     nodata: 0
-    aliases: [radiometric_saturation]
+    aliases: [radsat, radiometric_saturation]
     flags_definition:
       band_1_saturation:
         bits: 0
@@ -217,4 +217,4 @@ measurements:
     dtype: "int16"
     units: "Kelvin"
     nodata: -9999
-    aliases: [surface_temperature_quality]
+    aliases: [st_qa, surface_temperature_quality]

--- a/products/ls7_st.odc-product.yaml
+++ b/products/ls7_st.odc-product.yaml
@@ -1,0 +1,220 @@
+---
+name: ls7_st
+description: USGS Landsat 7 Collection 2 Level-2 Surface Temperature
+metadata_type: eo3
+
+license: CC-BY-4.0
+
+metadata:
+  product:
+    name: ls7_st
+
+measurements:
+  - name: ST_B6
+    dtype: "uint16"
+    units: "Kelvin"
+    nodata: 0
+    aliases: [band_6, surface_temperature]
+
+  - name: ST_TRAD
+    dtype: "int16"
+    units: "W/(m2.sr.μm)"
+    nodata: -9999
+    aliases: [thermal_radiance]
+
+  - name: ST_URAD
+    dtype: "int16"
+    units: "W/(m2.sr.μm)"
+    nodata: -9999
+    aliases: [upwell_radiance]
+
+  - name: ST_DRAD
+    dtype: "int16"
+    units: "W/(m2.sr.μm)"
+    nodata: -9999
+    aliases: [downwell_radiance]
+
+  - name: ST_ATRAN
+    dtype: "int16"
+    units: "1"
+    nodata: -9999
+    aliases: [atmospheric_transmittance]
+
+  - name: ST_EMIS
+    dtype: "int16"
+    units: "1"
+    nodata: -9999
+    aliases: [emissivity]
+
+  - name: ST_EMSD
+    dtype: "int16"
+    units: "1"
+    nodata: -9999
+    aliases: [emissivity_stddev]
+
+  - name: ST_CDIST
+    dtype: "int16"
+    units: "Kilometers"
+    nodata: -9999
+    aliases: [cloud_distance]
+
+  - name: QA_PIXEL
+    dtype: "uint16"
+    units: "bit_index"
+    nodata: 1
+    aliases: [pixel_quality]
+    flags_definition:
+      nodata:
+        bits: 0
+        values:
+          0: false
+          1: true
+      dilated_cloud:
+        bits: 1
+        values:
+          0: not_dilated
+          1: dilated
+      cloud:
+        bits: 3
+        values:
+          0: not_high_confidence
+          1: high_confidence
+      cloud_shadow:
+        bits: 4
+        values:
+          0: not_high_confidence
+          1: high_confidence
+      snow:
+        bits: 5
+        values:
+          0: not_high_confidence
+          1: high_confidence
+      clear:
+        bits: 6
+        values:
+          0: false
+          1: true
+      water:
+        bits: 7
+        values:
+          0: land_or_cloud
+          1: water
+      cloud_confidence:
+        bits: [8, 9]
+        values:
+          0: none
+          1: low
+          2: medium
+          3: high
+      cloud_shadow_confidence:
+        bits: [10, 11]
+        values:
+          0: none
+          1: low
+          2: reserved
+          3: high
+      snow_ice_confidence:
+        bits: [12, 13]
+        values:
+          0: none
+          1: low
+          2: reserved
+          3: high
+
+  - name: QA_RADSAT
+    dtype: "uint16"
+    units: "bit_index"
+    nodata: 0
+    aliases: [radiometric_saturation]
+    flags_definition:
+      band_1_saturation:
+        bits: 0
+        values:
+          0: false
+          1: true
+      band_2_saturation:
+        bits: 1
+        values:
+          0: false
+          1: true
+      band_3_saturation:
+        bits: 2
+        values:
+          0: false
+          1: true
+      band_4_saturation:
+        bits: 3
+        values:
+          0: false
+          1: true
+      band_5_saturation:
+        bits: 4
+        values:
+          0: false
+          1: true
+      band_6L_saturation:
+        bits: 5
+        values:
+          0: false
+          1: true
+      band_7_saturation:
+        bits: 6
+        values:
+          0: false
+          1: true
+      band_6H_saturation:
+        bits: 8
+        values:
+          0: false
+          1: true
+      blue_saturation:
+        bits: 0
+        values:
+          0: false
+          1: true
+      green_saturation:
+        bits: 1
+        values:
+          0: false
+          1: true
+      red_saturation:
+        bits: 2
+        values:
+          0: false
+          1: true
+      nir_saturation:
+        bits: 3
+        values:
+          0: false
+          1: true
+      swir_1_saturation:
+        bits: 4
+        values:
+          0: false
+          1: true
+      tir_l_saturation:
+        bits: 5
+        values:
+          0: false
+          1: true
+      tir_h_saturation:
+        bits: 8
+        values:
+          0: false
+          1: true
+      swir_2_saturation:
+        bits: 6
+        values:
+          0: false
+          1: true
+      dropped_pixel:
+        bits: 9
+        values:
+          0: false
+          1: true
+
+  - name: ST_QA
+    dtype: "int16"
+    units: "Kelvin"
+    nodata: -9999
+    aliases: [surface_temperature_quality]

--- a/products/ls8_sr.odc-product.yaml
+++ b/products/ls8_sr.odc-product.yaml
@@ -1,0 +1,239 @@
+---
+name: ls8_sr
+description: USGS Landsat 8 Collection 2 Level-2 Surface Reflectance
+metadata_type: eo3
+
+license: CC-BY-4.0
+
+metadata:
+  product:
+    name: ls8_sr
+
+measurements:
+  - name: SR_B1
+    units: "1"
+    dtype: "uint16"
+    nodata: 0
+    aliases: [band_1, coastal_aerosol]
+
+  - name: SR_B2
+    units: "1"
+    dtype: "uint16"
+    nodata: 0
+    aliases: [band_2, blue]
+
+  - name: SR_B3
+    units: "1"
+    dtype: "uint16"
+    nodata: 0
+    aliases: [band_3, green]
+
+  - name: SR_B4
+    units: "1"
+    dtype: "uint16"
+    nodata: 0
+    aliases: [band_4, red]
+
+  - name: SR_B5
+    units: "1"
+    dtype: "uint16"
+    nodata: 0
+    aliases: [band_5, nir]
+
+  - name: SR_B6
+    units: "1"
+    dtype: "uint16"
+    nodata: 0
+    aliases: [band_6, swir_1]
+
+  - name: SR_B7
+    units: "1"
+    dtype: "uint16"
+    nodata: 0
+    aliases: [band_7, swir_2]
+
+  - name: QA_PIXEL
+    dtype: "uint16"
+    units: "bit_index"
+    nodata: 1
+    aliases: [pixel_quality]
+    flags_definition:
+      nodata:
+        bits: 0
+        values:
+          0: false
+          1: true
+      dilated_cloud:
+        bits: 1
+        values:
+          0: not_dilated
+          1: dilated
+      cirrus:
+        bits: 2
+        values:
+          0: not_high_confidence
+          1: high_confidence
+      cloud:
+        bits: 3
+        values:
+          0: not_high_confidence
+          1: high_confidence
+      cloud_shadow:
+        bits: 4
+        values:
+          0: not_high_confidence
+          1: high_confidence
+      snow:
+        bits: 5
+        values:
+          0: not_high_confidence
+          1: high_confidence
+      clear:
+        bits: 6
+        values:
+          0: false
+          1: true
+      water:
+        bits: 7
+        values:
+          0: land_or_cloud
+          1: water
+      cloud_confidence:
+        bits: [8, 9]
+        values:
+          0: none
+          1: low
+          2: medium
+          3: high
+      cloud_shadow_confidence:
+        bits: [10, 11]
+        values:
+          0: none
+          1: low
+          2: reserved
+          3: high
+      snow_ice_confidence:
+        bits: [12, 13]
+        values:
+          0: none
+          1: low
+          2: reserved
+          3: high
+      cirrus_confidence:
+        bits: [14, 15]
+        values:
+          0: none
+          1: low
+          2: reserved
+          3: high
+
+  - name: QA_RADSAT
+    dtype: "uint16"
+    units: "bit_index"
+    nodata: 0
+    aliases: [radiometric_saturation]
+    flags_definition:
+      band_1_saturation:
+        bits: 0
+        values:
+          0: false
+          1: true
+      band_2_saturation:
+        bits: 1
+        values:
+          0: false
+          1: true
+      band_3_saturation:
+        bits: 2
+        values:
+          0: false
+          1: true
+      band_4_saturation:
+        bits: 3
+        values:
+          0: false
+          1: true
+      band_5_saturation:
+        bits: 4
+        values:
+          0: false
+          1: true
+      band_6_saturation:
+        bits: 5
+        values:
+          0: false
+          1: true
+      band_7_saturation:
+        bits: 6
+        values:
+          0: false
+          1: true
+      blue_saturation:
+        bits: 1
+        values:
+          0: false
+          1: true
+      green_saturation:
+        bits: 2
+        values:
+          0: false
+          1: true
+      red_saturation:
+        bits: 3
+        values:
+          0: false
+          1: true
+      nir_saturation:
+        bits: 4
+        values:
+          0: false
+          1: true
+      swir_1_saturation:
+        bits: 5
+        values:
+          0: false
+          1: true
+      swir_2_saturation:
+        bits: 6
+        values:
+          0: false
+          1: true
+      terrain_occlusion:
+        bits: 11
+        values:
+          0: false
+          1: true
+
+  - name: SR_QA_AEROSOL
+    dtype: "uint8"
+    units: "bit_index"
+    nodata: 1
+    aliases: [qa_aerosol]
+    flags_definition:
+      nodata:
+        bits: 0
+        values:
+          0: false
+          1: true
+      valid_aerosol_retrieval:
+        bits: 1
+        values:
+          0: false
+          1: true
+      water:
+        bits: 2
+        values:
+          0: false
+          1: true
+      interpolated_aerosol:
+        bits: 5
+        values:
+          0: false
+          1: true
+      aerosol_level:
+        bits: [6, 7]
+        values:
+          0: climatology
+          1: low
+          2: medium
+          3: high

--- a/products/ls8_sr.odc-product.yaml
+++ b/products/ls8_sr.odc-product.yaml
@@ -56,7 +56,7 @@ measurements:
     dtype: "uint16"
     units: "bit_index"
     nodata: 1
-    aliases: [pixel_quality]
+    aliases: [pq, pixel_quality]
     flags_definition:
       nodata:
         bits: 0
@@ -131,7 +131,7 @@ measurements:
     dtype: "uint16"
     units: "bit_index"
     nodata: 0
-    aliases: [radiometric_saturation]
+    aliases: [radsat, radiometric_saturation]
     flags_definition:
       band_1_saturation:
         bits: 0
@@ -208,7 +208,7 @@ measurements:
     dtype: "uint8"
     units: "bit_index"
     nodata: 1
-    aliases: [qa_aerosol]
+    aliases: [qa_aerosol, aerosol_qa]
     flags_definition:
       nodata:
         bits: 0

--- a/products/ls8_st.odc-product.yaml
+++ b/products/ls8_st.odc-product.yaml
@@ -1,104 +1,68 @@
 ---
-name: ls7_c2l2
-description: USGS Level 2 Collection 2 Landsat
+name: ls8_st
+description: USGS Landsat 8 Collection 2 Level-2 Surface Temperature
 metadata_type: eo3
 
 license: CC-BY-4.0
 
 metadata:
   product:
-    name: ls7_c2l2
+    name: ls8_st
 
 measurements:
-  - name: SR_B1
-    dtype: "uint16"
-    units: "1"
-    nodata: 0
-    aliases: [B1, band_1, blue]
-
-  - name: SR_B2
-    dtype: "uint16"
-    units: "1"
-    nodata: 0
-    aliases: [B2, band_2, green]
-
-  - name: SR_B3
-    dtype: "uint16"
-    units: "1"
-    nodata: 0
-    aliases: [B3, band_3, red]
-
-  - name: SR_B4
-    dtype: "uint16"
-    units: "1"
-    nodata: 0
-    aliases: [B4, band_4, nir]
-
-  - name: SR_B5
-    dtype: "uint16"
-    units: "1"
-    nodata: 0
-    aliases: [B5, band_5, swir_1]
-
-  - name: SR_B7
-    dtype: "uint16"
-    units: "1"
-    nodata: 0
-    aliases: [B7, band_7, swir_2]
-
-  - name: ST_B6
-    dtype: "uint16"
+  - name: ST_B10
     units: "Kelvin"
+    dtype: "uint16"
     nodata: 0
-    aliases: [B6, band_6, surface_temperature, land_surface_temperature]
+    aliases: [band_10, surface_temperature]
 
   - name: ST_TRAD
     dtype: "int16"
     units: "W/(m2.sr.μm)"
     nodata: -9999
-    aliases: [st_trad, thermal_radiance]
+    aliases: [thermal_radiance]
 
   - name: ST_URAD
     dtype: "int16"
     units: "W/(m2.sr.μm)"
     nodata: -9999
-    aliases: [st_urad, upwell_radiance]
+    aliases: [upwell_radiance]
 
   - name: ST_DRAD
     dtype: "int16"
     units: "W/(m2.sr.μm)"
     nodata: -9999
-    aliases: [st_drad, downwell_radiance]
+    aliases: [downwell_radiance]
 
   - name: ST_ATRAN
     dtype: "int16"
     units: "1"
     nodata: -9999
-    aliases: [st_atran, atmospheric_transmittance]
+    aliases: [atmospheric_transmittance]
 
   - name: ST_EMIS
     dtype: "int16"
     units: "1"
     nodata: -9999
-    aliases: [st_emis, emissivity]
+    aliases: [emissivity]
 
   - name: ST_EMSD
     dtype: "int16"
     units: "1"
     nodata: -9999
-    aliases: [st_emsd, emissivity_stddev, emissivity_standard_deviation]
+    aliases: [emissivity_stddev]
 
   - name: ST_CDIST
     dtype: "int16"
     units: "Kilometers"
     nodata: -9999
-    aliases: [st_cdist, cloud_distance]
+    aliases: [cloud_distance]
 
   - name: QA_PIXEL
     dtype: "uint16"
     units: "bit_index"
     nodata: 1
-    aliases: [quality_pixel, pixel_quality, pq]
+    aliases: [pixel_quality]
     flags_definition:
       nodata:
         bits: 0
@@ -110,6 +74,11 @@ measurements:
         values:
           0: not_dilated
           1: dilated
+      cirrus:
+        bits: 2
+        values:
+          0: not_high_confidence
+          1: high_confidence
       cloud:
         bits: 3
         values:
@@ -156,12 +125,19 @@ measurements:
           1: low
           2: reserved
           3: high
+      cirrus_confidence:
+        bits: [14, 15]
+        values:
+          0: none
+          1: low
+          2: reserved
+          3: high
 
   - name: QA_RADSAT
     dtype: "uint16"
     units: "bit_index"
     nodata: 0
-    aliases: [quality_radiometric_saturation, radiometric_saturation]
+    aliases: [radiometric_saturation]
     flags_definition:
       band_1_saturation:
         bits: 0
@@ -188,7 +164,7 @@ measurements:
         values:
           0: false
           1: true
-      band_6L_saturation:
+      band_6_saturation:
         bits: 5
         values:
           0: false
@@ -198,56 +174,38 @@ measurements:
         values:
           0: false
           1: true
-      band_6H_saturation:
-        bits: 8
-        values:
-          0: false
-          1: true
-      dropped_pixel:
-        bits: 9
-        values:
-          0: true
-          1: false
-
-  - name: SR_ATMOS_OPACITY
-    dtype: "int16"
-    units: "1"
-    nodata: -9999
-    aliases: [atmos_op, atmospheric_opacity]
-
-  - name: SR_CLOUD_QA
-    dtype: "uint8"
-    units: "bit_index"
-    nodata: 0
-    aliases: [cloud_qa, qa_cloud]
-    flags_definition:
-      dark_dense_vegetation:
-        bits: 0
-        values:
-          0: false
-          1: true
-      cloud:
+      blue_saturation:
         bits: 1
         values:
           0: false
           1: true
-      cloud_shadow:
+      green_saturation:
         bits: 2
         values:
           0: false
           1: true
-      adjacent_to_cloud:
+      red_saturation:
         bits: 3
         values:
           0: false
           1: true
-      snow:
+      nir_saturation:
         bits: 4
         values:
           0: false
           1: true
-      water:
+      swir_1_saturation:
         bits: 5
+        values:
+          0: false
+          1: true
+      swir_2_saturation:
+        bits: 6
+        values:
+          0: false
+          1: true
+      terrain_occlusion:
+        bits: 11
         values:
           0: false
           1: true
@@ -256,4 +214,4 @@ measurements:
     dtype: "int16"
     units: "Kelvin"
     nodata: -9999
-    aliases: [quality_surface_temperature, surface_temperature_quality]
+    aliases: [surface_temperature_quality]

--- a/products/ls8_st.odc-product.yaml
+++ b/products/ls8_st.odc-product.yaml
@@ -14,55 +14,55 @@ measurements:
     units: "Kelvin"
     dtype: "uint16"
     nodata: 0
-    aliases: [band_10, surface_temperature]
+    aliases: [band_10, st, surface_temperature]
 
   - name: ST_TRAD
     dtype: "int16"
     units: "W/(m2.sr.μm)"
     nodata: -9999
-    aliases: [thermal_radiance]
+    aliases: [trad, thermal_radiance]
 
   - name: ST_URAD
     dtype: "int16"
     units: "W/(m2.sr.μm)"
     nodata: -9999
-    aliases: [upwell_radiance]
+    aliases: [urad, upwell_radiance]
 
   - name: ST_DRAD
     dtype: "int16"
     units: "W/(m2.sr.μm)"
     nodata: -9999
-    aliases: [downwell_radiance]
+    aliases: [drad, downwell_radiance]
 
   - name: ST_ATRAN
     dtype: "int16"
     units: "1"
     nodata: -9999
-    aliases: [atmospheric_transmittance]
+    aliases: [atran, atmospheric_transmittance]
 
   - name: ST_EMIS
     dtype: "int16"
     units: "1"
     nodata: -9999
-    aliases: [emissivity]
+    aliases: [emis, emissivity]
 
   - name: ST_EMSD
     dtype: "int16"
     units: "1"
     nodata: -9999
-    aliases: [emissivity_stddev]
+    aliases: [emsd, emissivity_stddev]
 
   - name: ST_CDIST
     dtype: "int16"
     units: "Kilometers"
     nodata: -9999
-    aliases: [cloud_distance]
+    aliases: [cdist, cloud_distance]
 
   - name: QA_PIXEL
     dtype: "uint16"
     units: "bit_index"
     nodata: 1
-    aliases: [pixel_quality]
+    aliases: [pq, pixel_quality]
     flags_definition:
       nodata:
         bits: 0
@@ -137,7 +137,7 @@ measurements:
     dtype: "uint16"
     units: "bit_index"
     nodata: 0
-    aliases: [radiometric_saturation]
+    aliases: [radsat, radiometric_saturation]
     flags_definition:
       band_1_saturation:
         bits: 0
@@ -214,4 +214,4 @@ measurements:
     dtype: "int16"
     units: "Kelvin"
     nodata: -9999
-    aliases: [surface_temperature_quality]
+    aliases: [st_qa, surface_temperature_quality]


### PR DESCRIPTION
Split LS SR and ST into two products. SR include SR_ and QA_ bands. ST include ST_ and QA_ bands. Also updated alias to simply usage across the three LS and updated flags_definition to be more informative. 