### PR TITLE
the configuration file for S1 styling

### DIFF
--- a/services/ows_refactored/radar_backscatter/ows_sentinel1_cfg.py
+++ b/services/ows_refactored/radar_backscatter/ows_sentinel1_cfg.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+from ows_refactored.common.ows_reslim_cfg import reslim_alos_palsar
+
+bands_s1 = {"vv": [], "vh": [], "angle": [], "area": [], "mask": []}
+
+
+style_s1_vv = {
+    "name": "vv",
+    "title": "VV",
+    "abstract": "VV band",
+    "additional_bands": [],
+    "components": {"red": {"vv": 1.0,"scale_range":[0.0,0.28]},
+        "green": {"vv": 1.0,"scale_range":[0.0,0.28]},
+        "blue": {"vv": 1.0,"scale_range":[0.0,0.28]},
+    },
+}
+
+style_s1_vh = {
+    "name": "vh",
+    "title": "VH",
+    "abstract": "VH band",
+    "additional_bands": [],
+    "components": {
+        "red": {"vh": 1.0,"scale_range":[0.0,0.06]},
+        "green": {"vh": 1.0,"scale_range":[0.0,0.06]},
+        "blue": {"vh": 1.0,"scale_range":[0.0,0.06]},
+    },
+}
+
+
+style_s1_vh_over_vv= {
+    "name": "vv_vh_vv_over_vv",
+    "title": "VV, VH and VH/VV",
+    "abstract": "False colour representation of VV, VH and VH/VV for R, G and B respectively",
+    "additional_bands": [],
+    "components": {
+        "red": {"vv":1.0,"scale_range":[0.0,0.28]},
+        "green": {"vh":1.0,"scale_range":[0.0,0.06]},
+        "blue": {
+            "function": "datacube_ows.band_utils.band_quotient",
+            "mapped_bands": True,
+            "kwargs": {"band1": "vh", "band2": "vv", "scale_from":[0.0,0.49]},
+        },
+    },
+}
+
+layer = {
+    "title": "Normalized Radar Backscatter Sentinel-1",
+    "name": "s1_rtc",
+    "abstract": """
+
+Synthetic Aperture Radar (SAR) data have been shown to provide different and complementary information to the more common optical remote sensing data. Radar backscatter response is a function of topography, land cover structure, orientation, and moisture characteristics—including vegetation biomass—and the radar signal can penetrate clouds, providing information about the earth’s surface where optical sensors cannot. Digital Earth Africa provides access to Normalized Radar Backscatter data, for which Radiometric Terrain Correction (RTC) has been applied so data acquired with different imaging geometries over the same region can be compared. 
+
+The twin Sentinel-1 satellites, launched in 2014 and 2016, are operated by the European Space Agency (ESA) as part of European Commission's Copernicus Programme. They currently collects C-band SAR data every 12 days over Africa. 
+
+This product contains radar measurement in C-band and in VV and VH polarizations. It has a spatial resolution of approximate 20 m, a temporal coverage of 2017 to current and is updated as new images are acquired. Data is provided as Gamma0 in linear power, which can be converted to backscatter in decibel unit using 10*log10(DN).
+
+This dataset is processed by Sinergise Sentinel Hub using Sentinel-1 GRD product provided by ESA as input. RTC has been calcuated using 30 m Copernicus Digital Elevation Model.
+
+More techincal information about the Sentinel-1 Normalized Backscatter can be found in the User Guide (https://docs.digitalearthafrica.org/en/latest/data_specs/Sentinel-1_specs.html)
+
+This product is accessible through OGC Web Service (https://ows.digitalearth.africa/), for analysis in DE Africa Sandbox JupyterLab (https://github.com/digitalearthafrica/deafrica-sandbox-notebooks/wiki) and for direct download from AWS S3 (https://data.digitalearth.africa/).
+""",
+    "product_name": "s1_rtc",
+    "time_resolution": "year",
+    "bands": bands_s1,
+    "resource_limits": reslim_alos_palsar, #the argument need to be checked as it was already set to be SRTM 
+    "image_processing": {
+        "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
+        "always_fetch_bands": [],
+        "manual_merge": False,
+    },
+    "flags": {
+        "product": "s1_rtc",
+        "band": "mask",
+        "ignore_info_flags": [],
+    },
+    "wcs": {
+        "native_crs": "EPSG:4326",
+        "native_resolution": [0.000222222222222, -0.000222222222222],
+        "default_bands": ["vv", "vh", "angle","area","mask"],
+    },
+    "styling": {
+        "default_style": "hh",
+        "styles": [
+            style_s1_vv,
+            style_s1_vh,
+            style_s1_vh_over_vv,
+        ],
+    },
+}

--- a/services/ows_refactored/radar_backscatter/ows_sentinel1_cfg.py
+++ b/services/ows_refactored/radar_backscatter/ows_sentinel1_cfg.py
@@ -13,6 +13,13 @@ style_s1_vv = {
         "green": {"vv": 1.0,"scale_range":[0.0,0.28]},
         "blue": {"vv": 1.0,"scale_range":[0.0,0.28]},
     },
+    "pq_masks": [
+        {
+            #Only make mask=1 pixels (valid data) visible.
+            "band":"mask",
+            "enum":1,
+        },
+    ],
 }
 
 style_s1_vh = {
@@ -25,11 +32,18 @@ style_s1_vh = {
         "green": {"vh": 1.0,"scale_range":[0.0,0.06]},
         "blue": {"vh": 1.0,"scale_range":[0.0,0.06]},
     },
+    "pq_masks": [
+        {
+            #Only make mask=1 pixels (valid data) visible.
+            "band":"mask",
+            "enum":1,
+        },
+    ],
 }
 
 
 style_s1_vh_over_vv= {
-    "name": "vv_vh_vv_over_vv",
+    "name": "vv_vh_vh_over_vv",
     "title": "VV, VH and VH/VV",
     "abstract": "False colour representation of VV, VH and VH/VV for R, G and B respectively",
     "additional_bands": [],
@@ -42,6 +56,13 @@ style_s1_vh_over_vv= {
             "kwargs": {"band1": "vh", "band2": "vv", "scale_from":[0.0,0.49]},
         },
     },
+    "pq_masks": [
+        {
+            #Only make mask=1 pixels (valid data) visible.
+            "band":"mask",
+            "enum":1,
+        },
+    ],    
 }
 
 layer = {
@@ -64,17 +85,13 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
     "product_name": "s1_rtc",
     "time_resolution": "year",
     "bands": bands_s1,
-    "resource_limits": reslim_alos_palsar, #the argument need to be checked as it was already set to be SRTM 
+    "resource_limits": reslim_alos_palsar,  
     "image_processing": {
         "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
         "always_fetch_bands": [],
         "manual_merge": False,
     },
-    "flags": {
-        "product": "s1_rtc",
-        "band": "mask",
-        "ignore_info_flags": [],
-    },
+    
     "wcs": {
         "native_crs": "EPSG:4326",
         "native_resolution": [0.000222222222222, -0.000222222222222],

--- a/services/ows_refactored/radar_backscatter/ows_sentinel1_cfg.py
+++ b/services/ows_refactored/radar_backscatter/ows_sentinel1_cfg.py
@@ -10,9 +10,9 @@ style_s1_vv = {
     "abstract": "VV band",
     "additional_bands": [],
     "components": {
-        "red": {"vv": 1.0, "scale_range": [0.0,0.28]}, 
-        "green": {"vv": 1.0, "scale_range": [0.0,0.28]}, 
-        "blue": {"vv": 1.0, "scale_range": [0.0,0.28]}, 
+        "red": {"vv": 1.0 , "scale_range": [0.0,0.28]}, 
+        "green": {"vv": 1.0 , "scale_range": [0.0,0.28]}, 
+        "blue": {"vv": 1.0 , "scale_range": [0.0,0.28]}, 
     },
     "pq_masks": [
         {
@@ -29,9 +29,9 @@ style_s1_vh = {
     "abstract": "VH band",
     "additional_bands": [],
     "components": {
-        "red": {"vh": 1.0,"scale_range": [0.0,0.06]}, 
-        "green": {"vh": 1.0,"scale_range": [0.0,0.06]}, 
-        "blue": {"vh": 1.0,"scale_range": [0.0,0.06]}, 
+        "red": {"vh": 1.0, "scale_range": [0.0,0.06]}, 
+        "green": {"vh": 1.0, "scale_range": [0.0,0.06]}, 
+        "blue": {"vh": 1.0, "scale_range": [0.0,0.06]}, 
     },
     "pq_masks": [
         {
@@ -48,12 +48,12 @@ style_s1_vh_over_vv= {
     "abstract": "False colour representation of VV, VH and VH/VV for R, G and B respectively",
     "additional_bands": [],
     "components": {
-        "red": {"vv":1.0, "scale_range": [0.0,0.28]},
-        "green": {"vh":1.0, "scale_range": [0.0,0.06]},
+        "red": {"vv":1.0, "scale_range": [0.0,0.28]}, 
+        "green": {"vh":1.0, "scale_range": [0.0,0.06]}, 
         "blue": {
             "function": "datacube_ows.band_utils.band_quotient",
             "mapped_bands": True,
-            "kwargs": {"band1": "vh", "band2": "vv", "scale_from": [0.0,0.49]},
+            "kwargs": {"band1": "vh", "band2": "vv", "scale_from": [0.0,0.49]}, 
         },
     },
     "pq_masks": [

--- a/services/ows_refactored/radar_backscatter/ows_sentinel1_cfg.py
+++ b/services/ows_refactored/radar_backscatter/ows_sentinel1_cfg.py
@@ -11,14 +11,13 @@ style_s1_vv = {
     "additional_bands": [],
     "components": {
         "red": {"vv": 1.0, "scale_range": [0.0, 0.28]},
-        "green": {"vv": 1.0,"scale_range": [0.0, 0.28]},
-        "blue": {"vv": 1.0 ,"scale_range": [0.0, 0.28]}, 
+        "green": {"vv": 1.0, "scale_range": [0.0, 0.28]},
+        "blue": {"vv": 1.0, "scale_range": [0.0, 0.28]},
     },
     "pq_masks": [
         {
-            #Only make mask=1 pixels (valid data) visible.
-            "band":"mask",
-            "enum":1,
+            "band": "mask",
+            "enum": 1,
         },
     ],
 }
@@ -31,7 +30,7 @@ style_s1_vh = {
     "components": {
         "red": {"vh": 1.0, "scale_range": [0.0, 0.06]},
         "green": {"vh": 1.0, "scale_range": [0.0, 0.06]},
-        "blue": {"vh": 1.0, "scale_range": [0.0, 0.06]}, 
+        "blue": {"vh": 1.0, "scale_range": [0.0, 0.06]},
     },
     "pq_masks": [
         {
@@ -42,7 +41,7 @@ style_s1_vh = {
     ],
 }
 
-style_s1_vh_over_vv= {
+style_s1_vh_over_vv = {
     "name": "vv_vh_vh_over_vv",
     "title": "VV, VH and VH/VV",
     "abstract": "False colour representation of VV, VH and VH/VV for R, G and B respectively",
@@ -70,8 +69,10 @@ layer = {
     "name": "s1_rtc",
     "abstract": """
 
-Synthetic Aperture Radar (SAR) data have been shown to provide different and complementary information to the more common optical remote sensing data. Radar backscatter response is a function of topography, land cover structure, orientation, and moisture characteristics—including vegetation biomass—and the radar signal can penetrate clouds, providing information about the earth’s surface where optical sensors cannot. Digital Earth Africa provides access to Normalized Radar Backscatter data, for which Radiometric Terrain Correction (RTC) has been applied so data acquired with different imaging geometries over the same region can be compared. 
-The twin Sentinel-1 satellites, launched in 2014 and 2016, are operated by the European Space Agency (ESA) as part of European Commission's Copernicus Programme. They currently collects C-band SAR data every 12 days over Africa. 
+Synthetic Aperture Radar (SAR) data have been shown to provide different and complementary information to the more common optical remote sensing data. Radar backscatter response is a function of topography, land cover structure, orientation, and moisture characteristics—including vegetation biomass—and the radar signal can penetrate clouds, providing information about the earth’s surface where optical sensors cannot. Digital Earth Africa provides access to Normalized Radar Backscatter data, for which Radiometric Terrain Correction (RTC) has been applied so data acquired with different imaging geometries over the same region can be compared.
+
+The twin Sentinel-1 satellites, launched in 2014 and 2016, are operated by the European Space Agency (ESA) as part of European Commission's Copernicus Programme. They currently collects C-band SAR data every 12 days over Africa.
+
 This product contains radar measurement in C-band and in VV and VH polarizations. It has a spatial resolution of approximate 20 m, a temporal coverage of 2017 to current and is updated as new images are acquired. Data is provided as Gamma0 in linear power, which can be converted to backscatter in decibel unit using 10*log10(DN).
 
 This dataset is processed by Sinergise Sentinel Hub using Sentinel-1 GRD product provided by ESA as input. RTC has been calcuated using 30 m Copernicus Digital Elevation Model.

--- a/services/ows_refactored/radar_backscatter/ows_sentinel1_cfg.py
+++ b/services/ows_refactored/radar_backscatter/ows_sentinel1_cfg.py
@@ -80,6 +80,7 @@ More techincal information about the Sentinel-1 Normalized Backscatter can be fo
 This product is accessible through OGC Web Service (https://ows.digitalearth.africa/), for analysis in DE Africa Sandbox JupyterLab (https://github.com/digitalearthafrica/deafrica-sandbox-notebooks/wiki) and for direct download from AWS S3 (https://data.digitalearth.africa/).
 """,
     "product_name": "s1_rtc",
+    "dynamic": True,
     "bands": bands_s1,
     "resource_limits": reslim_alos_palsar,
     "image_processing": {
@@ -95,9 +96,9 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
     "styling": {
         "default_style": "vh_over_vv",
         "styles": [
+            style_s1_vh_over_vv,
             style_s1_vv,
             style_s1_vh,
-            style_s1_vh_over_vv,
         ],
     },
 }

--- a/services/ows_refactored/radar_backscatter/ows_sentinel1_cfg.py
+++ b/services/ows_refactored/radar_backscatter/ows_sentinel1_cfg.py
@@ -34,9 +34,8 @@ style_s1_vh = {
     },
     "pq_masks": [
         {
-            #Only make mask=1 pixels (valid data) visible.
-            "band":"mask",
-            "enum":1,
+            "band": "mask",
+            "enum": 1,
         },
     ],
 }
@@ -47,8 +46,8 @@ style_s1_vh_over_vv = {
     "abstract": "False colour representation of VV, VH and VH/VV for R, G and B respectively",
     "additional_bands": [],
     "components": {
-        "red": {"vv":1.0, "scale_range": [0.0, 0.28]},
-        "green": {"vh":1.0, "scale_range": [0.0, 0.06]},
+        "red": {"vv": 1.0, "scale_range": [0.0, 0.28]},
+        "green": {"vh": 1.0, "scale_range": [0.0, 0.06]},
         "blue": {
             "function": "datacube_ows.band_utils.band_quotient",
             "mapped_bands": True,
@@ -57,9 +56,8 @@ style_s1_vh_over_vv = {
     },
     "pq_masks": [
         {
-            #Only make mask=1 pixels (valid data) visible.
-            "band":"mask",
-            "enum":1,
+            "band": "mask",
+            "enum": 1,
         },
     ],
 }
@@ -93,7 +91,7 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
     "wcs": {
         "native_crs": "EPSG:4326",
         "native_resolution": [0.000222222222222, -0.000222222222222],
-        "default_bands": ["vv", "vh", "angle","area","mask"],
+        "default_bands": ["vv", "vh", "angle", "area", "mask"],
     },
     "styling": {
         "default_style": "hh",

--- a/services/ows_refactored/radar_backscatter/ows_sentinel1_cfg.py
+++ b/services/ows_refactored/radar_backscatter/ows_sentinel1_cfg.py
@@ -80,7 +80,6 @@ More techincal information about the Sentinel-1 Normalized Backscatter can be fo
 This product is accessible through OGC Web Service (https://ows.digitalearth.africa/), for analysis in DE Africa Sandbox JupyterLab (https://github.com/digitalearthafrica/deafrica-sandbox-notebooks/wiki) and for direct download from AWS S3 (https://data.digitalearth.africa/).
 """,
     "product_name": "s1_rtc",
-    "time_resolution": "year",
     "bands": bands_s1,
     "resource_limits": reslim_alos_palsar,
     "image_processing": {
@@ -90,11 +89,11 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
     },
     "wcs": {
         "native_crs": "EPSG:4326",
-        "native_resolution": [0.000222222222222, -0.000222222222222],
+        "native_resolution": [0.0002, -0.0002],
         "default_bands": ["vv", "vh", "angle", "area", "mask"],
     },
     "styling": {
-        "default_style": "hh",
+        "default_style": "vh_over_vv",
         "styles": [
             style_s1_vv,
             style_s1_vh,

--- a/services/ows_refactored/radar_backscatter/ows_sentinel1_cfg.py
+++ b/services/ows_refactored/radar_backscatter/ows_sentinel1_cfg.py
@@ -9,9 +9,10 @@ style_s1_vv = {
     "title": "VV",
     "abstract": "VV band",
     "additional_bands": [],
-    "components": {"red": {"vv": 1.0,"scale_range":[0.0,0.28]},
-        "green": {"vv": 1.0,"scale_range":[0.0,0.28]},
-        "blue": {"vv": 1.0,"scale_range":[0.0,0.28]},
+    "components": {
+        "red": {"vv": 1.0, "scale_range": [0.0,0.28]}, 
+        "green": {"vv": 1.0, "scale_range": [0.0,0.28]}, 
+        "blue": {"vv": 1.0, "scale_range": [0.0,0.28]}, 
     },
     "pq_masks": [
         {
@@ -28,9 +29,9 @@ style_s1_vh = {
     "abstract": "VH band",
     "additional_bands": [],
     "components": {
-        "red": {"vh": 1.0,"scale_range":[0.0,0.06]},
-        "green": {"vh": 1.0,"scale_range":[0.0,0.06]},
-        "blue": {"vh": 1.0,"scale_range":[0.0,0.06]},
+        "red": {"vh": 1.0,"scale_range": [0.0,0.06]}, 
+        "green": {"vh": 1.0,"scale_range": [0.0,0.06]}, 
+        "blue": {"vh": 1.0,"scale_range": [0.0,0.06]}, 
     },
     "pq_masks": [
         {
@@ -41,19 +42,18 @@ style_s1_vh = {
     ],
 }
 
-
 style_s1_vh_over_vv= {
     "name": "vv_vh_vh_over_vv",
     "title": "VV, VH and VH/VV",
     "abstract": "False colour representation of VV, VH and VH/VV for R, G and B respectively",
     "additional_bands": [],
     "components": {
-        "red": {"vv":1.0,"scale_range":[0.0,0.28]},
-        "green": {"vh":1.0,"scale_range":[0.0,0.06]},
+        "red": {"vv":1.0, "scale_range": [0.0,0.28]},
+        "green": {"vh":1.0, "scale_range": [0.0,0.06]},
         "blue": {
             "function": "datacube_ows.band_utils.band_quotient",
             "mapped_bands": True,
-            "kwargs": {"band1": "vh", "band2": "vv", "scale_from":[0.0,0.49]},
+            "kwargs": {"band1": "vh", "band2": "vv", "scale_from": [0.0,0.49]},
         },
     },
     "pq_masks": [
@@ -62,7 +62,7 @@ style_s1_vh_over_vv= {
             "band":"mask",
             "enum":1,
         },
-    ],    
+    ],
 }
 
 layer = {
@@ -71,9 +71,7 @@ layer = {
     "abstract": """
 
 Synthetic Aperture Radar (SAR) data have been shown to provide different and complementary information to the more common optical remote sensing data. Radar backscatter response is a function of topography, land cover structure, orientation, and moisture characteristics—including vegetation biomass—and the radar signal can penetrate clouds, providing information about the earth’s surface where optical sensors cannot. Digital Earth Africa provides access to Normalized Radar Backscatter data, for which Radiometric Terrain Correction (RTC) has been applied so data acquired with different imaging geometries over the same region can be compared. 
-
 The twin Sentinel-1 satellites, launched in 2014 and 2016, are operated by the European Space Agency (ESA) as part of European Commission's Copernicus Programme. They currently collects C-band SAR data every 12 days over Africa. 
-
 This product contains radar measurement in C-band and in VV and VH polarizations. It has a spatial resolution of approximate 20 m, a temporal coverage of 2017 to current and is updated as new images are acquired. Data is provided as Gamma0 in linear power, which can be converted to backscatter in decibel unit using 10*log10(DN).
 
 This dataset is processed by Sinergise Sentinel Hub using Sentinel-1 GRD product provided by ESA as input. RTC has been calcuated using 30 m Copernicus Digital Elevation Model.
@@ -85,13 +83,12 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
     "product_name": "s1_rtc",
     "time_resolution": "year",
     "bands": bands_s1,
-    "resource_limits": reslim_alos_palsar,  
+    "resource_limits": reslim_alos_palsar,
     "image_processing": {
         "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
         "always_fetch_bands": [],
         "manual_merge": False,
     },
-    
     "wcs": {
         "native_crs": "EPSG:4326",
         "native_resolution": [0.000222222222222, -0.000222222222222],

--- a/services/ows_refactored/radar_backscatter/ows_sentinel1_cfg.py
+++ b/services/ows_refactored/radar_backscatter/ows_sentinel1_cfg.py
@@ -94,7 +94,7 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
         "default_bands": ["vv", "vh", "angle", "area", "mask"],
     },
     "styling": {
-        "default_style": "vh_over_vv",
+        "default_style": "vv_vh_vh_over_vv",
         "styles": [
             style_s1_vh_over_vv,
             style_s1_vv,

--- a/services/ows_refactored/radar_backscatter/ows_sentinel1_cfg.py
+++ b/services/ows_refactored/radar_backscatter/ows_sentinel1_cfg.py
@@ -10,9 +10,9 @@ style_s1_vv = {
     "abstract": "VV band",
     "additional_bands": [],
     "components": {
-        "red": {"vv": 1.0 , "scale_range": [0.0,0.28]}, 
-        "green": {"vv": 1.0 , "scale_range": [0.0,0.28]}, 
-        "blue": {"vv": 1.0 , "scale_range": [0.0,0.28]}, 
+        "red": {"vv": 1.0, "scale_range": [0.0, 0.28]},
+        "green": {"vv": 1.0,"scale_range": [0.0, 0.28]},
+        "blue": {"vv": 1.0 ,"scale_range": [0.0, 0.28]}, 
     },
     "pq_masks": [
         {
@@ -29,9 +29,9 @@ style_s1_vh = {
     "abstract": "VH band",
     "additional_bands": [],
     "components": {
-        "red": {"vh": 1.0, "scale_range": [0.0,0.06]}, 
-        "green": {"vh": 1.0, "scale_range": [0.0,0.06]}, 
-        "blue": {"vh": 1.0, "scale_range": [0.0,0.06]}, 
+        "red": {"vh": 1.0, "scale_range": [0.0, 0.06]},
+        "green": {"vh": 1.0, "scale_range": [0.0, 0.06]},
+        "blue": {"vh": 1.0, "scale_range": [0.0, 0.06]}, 
     },
     "pq_masks": [
         {
@@ -48,12 +48,12 @@ style_s1_vh_over_vv= {
     "abstract": "False colour representation of VV, VH and VH/VV for R, G and B respectively",
     "additional_bands": [],
     "components": {
-        "red": {"vv":1.0, "scale_range": [0.0,0.28]}, 
-        "green": {"vh":1.0, "scale_range": [0.0,0.06]}, 
+        "red": {"vv":1.0, "scale_range": [0.0, 0.28]},
+        "green": {"vh":1.0, "scale_range": [0.0, 0.06]},
         "blue": {
             "function": "datacube_ows.band_utils.band_quotient",
             "mapped_bands": True,
-            "kwargs": {"band1": "vh", "band2": "vv", "scale_from": [0.0,0.49]}, 
+            "kwargs": {"band1": "vh", "band2": "vv", "scale_from": [0.0, 0.49]},
         },
     },
     "pq_masks": [


### PR DESCRIPTION
Could you please review the items in the Sentinel-1 OWS styling configuration file. 
I also need to get confirmation that 
"resource_limits": reslim_alos_palsar
will follow the same pattern as the ALOS dataset - reslim_alos_palsar follows SRTM in https://github.com/digitalearthafrica/config/blob/master/services/ows_refactored/common/ows_reslim_cfg.py