### PR TITLE
OWS styles for Landsat C2 data

### DIFF
--- a/services/ows_refactored/surface_reflectance/band_sr_cfg.py
+++ b/services/ows_refactored/surface_reflectance/band_sr_cfg.py
@@ -61,26 +61,3 @@ bands_lsc2_sr = {
     "swir_1": ["shortwave_infrared_1", "near_shortwave_infrared"],
     "swir_2": ["shortwave_infrared_2", "far_shortwave_infrared"],
 }
-
-# separate styles are not good
-# they prevent the ability to have a combined 
-# LS5/7/8 layer
-
-# bands_ls57c2_sr = {
-#     "SR_B1": ["band_1", "blue"],
-#     "SR_B2": ["band_2", "green"],
-#     "SR_B3": ["band_3", "red"],
-#     "SR_B4": ["band_4", "nir"] ,
-#     "SR_B5": ["band_5", "swir_1"],
-#     "SR_B7": ["band_7", "swir_2"]
-# }
-
-# bands_ls8c2_sr = {
-#     "SR_B1": ["band_1", "coastal_aerosol"],
-#     "SR_B2": ["band_2", "blue"],
-#     "SR_B3": ["band_3", "green"],
-#     "SR_B4": ["band_4", "red"] ,
-#     "SR_B5": ["band_5", "nir"],
-#     "SR_B6": ["band_6", "swir_1"],
-#     "SR_B7": ["band_7", "swir_2"]
-# }

--- a/services/ows_refactored/surface_reflectance/band_sr_cfg.py
+++ b/services/ows_refactored/surface_reflectance/band_sr_cfg.py
@@ -50,3 +50,37 @@ bands_ls = {
     "swir1": ["shortwave_infrared_1", "near_shortwave_infrared"],
     "swir2": ["shortwave_infrared_2", "far_shortwave_infrared"],
 }
+
+# new styles for C2 Landsat
+
+bands_lsc2_sr = {
+    "red": [],
+    "green": [],
+    "blue": [],
+    "nir": ["near_infrared"],
+    "swir_1": ["shortwave_infrared_1", "near_shortwave_infrared"],
+    "swir_2": ["shortwave_infrared_2", "far_shortwave_infrared"],
+}
+
+# separate styles are not good
+# they prevent the ability to have a combined 
+# LS5/7/8 layer
+
+# bands_ls57c2_sr = {
+#     "SR_B1": ["band_1", "blue"],
+#     "SR_B2": ["band_2", "green"],
+#     "SR_B3": ["band_3", "red"],
+#     "SR_B4": ["band_4", "nir"] ,
+#     "SR_B5": ["band_5", "swir_1"],
+#     "SR_B7": ["band_7", "swir_2"]
+# }
+
+# bands_ls8c2_sr = {
+#     "SR_B1": ["band_1", "coastal_aerosol"],
+#     "SR_B2": ["band_2", "blue"],
+#     "SR_B3": ["band_3", "green"],
+#     "SR_B4": ["band_4", "red"] ,
+#     "SR_B5": ["band_5", "nir"],
+#     "SR_B6": ["band_6", "swir_1"],
+#     "SR_B7": ["band_7", "swir_2"]
+# }

--- a/services/ows_refactored/surface_reflectance/ows_lsc2_sr_cfg.py
+++ b/services/ows_refactored/surface_reflectance/ows_lsc2_sr_cfg.py
@@ -1,0 +1,125 @@
+from ows_refactored.common.ows_reslim_cfg import reslim_landsat
+from ows_refactored.surface_reflectance.band_sr_cfg import bands_lsc2_sr
+from ows_refactored.surface_reflectance.style_sr_cfg import styles_lsc2_sr_list
+
+layers = {
+    "title": "Landsat",
+    "abstract": """Landsat represents a collection of space-based land remote sensing data. Surface reflectance
+                        measures incoming solar radiation reflected from the Earth to the Landsat sensor, which improves comparison
+                        between multiple images over the same region. This helps us detect Earth surface changes. This dataset
+                        includes Landsat 8 US Geological Survey Collection 1 Higher Level SR scene processed using LaSRC. 30m UTM
+                        based projection.""",
+    "layers": [
+        {
+            "title": "Surface Reflectance Landsat 8 (USGS Collection 2)",
+            "name": "ls8_sr",
+            "abstract": """
+Surface reflectance is the fraction of incoming solar radiation that is reflected from Earth's surface. Variations in satellite measured radiance due to atmospheric properties have been corrected for, so images acquired over the same area at different times are comparable and can be used readily to detect changes on Earth’s surface.
+
+DE Africa provides access to Landsat Collection 2 Level-2 Surface Reflectance products over Africa. USGS Landsat Collection 2 offers improved processing, geometric accuracy, and radiometric calibration compared to previous Collection 1 products. The Level-2 products are endorsed by the Committee on Earth Observation Satellites (CEOS) to be Analysis Ready Data for Land (CARD4L)-compliant.
+
+More techincal information about the Landsat Surface Reflectance product can be found in the User Guide (https://docs.digitalearthafrica.org/en/latest/data_specs/Landsat_C2_SR_specs.html).
+
+Landsat 8 product has a spatial resolution of 30 m and a temporal coverage of 2013 to present.
+
+Landsat Level- 2 Surface Reflectance Science Product courtesy of the U.S. Geological Survey.
+
+For more information on Landsat products, see https://www.usgs.gov/core-science-systems/nli/landsat/landsat-collection-2-level-2-science-products.
+
+This product is accessible through OGC Web Service (https://ows.digitalearth.africa/), for analysis in DE Africa Sandbox JupyterLab (https://github.com/digitalearthafrica/deafrica-sandbox-notebooks/wiki) and for direct download from AWS S3 (https://data.digitalearth.africa/).
+""",
+            "product_name": "ls8_sr",
+            "bands": bands_lsc2_sr,
+            "resource_limits": reslim_landsat,
+            "image_processing": {
+                "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
+                "always_fetch_bands": [],
+                "manual_merge": False,  # True
+                "apply_solar_corrections": False,
+            },
+            "wcs": {
+                "native_crs": "EPSG:4326",
+                "native_resolution": [30.0, -30.0],
+                "default_bands": ["red", "green", "blue"],
+            },
+            "styling": {
+                "default_style": "simple_rgb",
+                "styles": styles_lsc2_sr_list,
+            },
+        },
+        {
+            "title": "Surface Reflectance Landsat 7 (USGS Collection 2)",
+            "name": "ls7_sr",
+            "abstract": """
+Surface reflectance is the fraction of incoming solar radiation that is reflected from Earth's surface. Variations in satellite measured radiance due to atmospheric properties have been corrected for, so images acquired over the same area at different times are comparable and can be used readily to detect changes on Earth’s surface.
+
+DE Africa provides access to Landsat Collection 2 Level-2 Surface Reflectance products over Africa. USGS Landsat Collection 2 offers improved processing, geometric accuracy, and radiometric calibration compared to previous Collection 1 products. The Level-2 products are endorsed by the Committee on Earth Observation Satellites (CEOS) to be Analysis Ready Data for Land (CARD4L)-compliant.
+
+More techincal information about the Landsat Surface Reflectance product can be found in the User Guide (https://docs.digitalearthafrica.org/en/latest/data_specs/Landsat_C2_SR_specs.html).
+
+Landsat 7 product has a spatial resolution of 30 m and a temporal coverage of 1999 to present.
+
+Landsat Level- 2 Surface Reflectance Science Product courtesy of the U.S. Geological Survey.
+
+For more information on Landsat products, see https://www.usgs.gov/core-science-systems/nli/landsat/landsat-collection-2-level-2-science-products.
+
+This product is accessible through OGC Web Service (https://ows.digitalearth.africa/), for analysis in DE Africa Sandbox JupyterLab (https://github.com/digitalearthafrica/deafrica-sandbox-notebooks/wiki) and for direct download from AWS S3 (https://data.digitalearth.africa/).
+""",
+            "product_name": "ls7_sr",
+            "bands": bands_lsc2_sr,
+            "resource_limits": reslim_landsat,
+            "image_processing": {
+                "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
+                "always_fetch_bands": [],
+                "manual_merge": False,  # True
+                "apply_solar_corrections": False,
+            },
+            "wcs": {
+                "native_crs": "EPSG:4326",
+                "native_resolution": [30.0, -30.0],
+                "default_bands": ["red", "green", "blue"],
+            },
+            "styling": {
+                "default_style": "simple_rgb",
+                "styles": styles_lsc2_sr_list,
+            },
+        },
+        {
+            "title": "Surface Reflectance Landsat 5 (USGS Collection 2)",
+            "name": "ls5_sr",
+            "abstract": """
+Surface reflectance is the fraction of incoming solar radiation that is reflected from Earth's surface. Variations in satellite measured radiance due to atmospheric properties have been corrected for, so images acquired over the same area at different times are comparable and can be used readily to detect changes on Earth’s surface.
+
+DE Africa provides access to Landsat Collection 2 Level-2 Surface Reflectance products over Africa. USGS Landsat Collection 2 offers improved processing, geometric accuracy, and radiometric calibration compared to previous Collection 1 products. The Level-2 products are endorsed by the Committee on Earth Observation Satellites (CEOS) to be Analysis Ready Data for Land (CARD4L)-compliant.
+
+More techincal information about the Landsat Surface Reflectance product can be found in the User Guide (https://docs.digitalearthafrica.org/en/latest/data_specs/Landsat_C2_SR_specs.html).
+
+Landsat 5 product has a spatial resolution of 30 m and a temporal coverage of 1984 to 2012.
+
+Landsat Level- 2 Surface Reflectance Science Product courtesy of the U.S. Geological Survey.
+
+For more information on Landsat products, see https://www.usgs.gov/core-science-systems/nli/landsat/landsat-collection-2-level-2-science-products.
+
+This product is accessible through OGC Web Service (https://ows.digitalearth.africa/), for analysis in DE Africa Sandbox JupyterLab (https://github.com/digitalearthafrica/deafrica-sandbox-notebooks/wiki) and for direct download from AWS S3 (https://data.digitalearth.africa/).
+""",
+            "product_name": "ls5_sr",
+            "bands": bands_lsc2_sr,
+            "resource_limits": reslim_landsat,
+            "image_processing": {
+                "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
+                "always_fetch_bands": [],
+                "manual_merge": False,  # True
+                "apply_solar_corrections": False,
+            },
+            "wcs": {
+                "native_crs": "EPSG:4326",
+                "native_resolution": [30.0, -30.0],
+                "default_bands": ["red", "green", "blue"],
+            },
+            "styling": {
+                "default_style": "simple_rgb",
+                "styles": styles_lsc2_sr_list,
+            },
+        },
+    ],
+}

--- a/services/ows_refactored/surface_reflectance/ows_sr_cfg.py
+++ b/services/ows_refactored/surface_reflectance/ows_sr_cfg.py
@@ -1,6 +1,6 @@
 from ows_refactored.common.ows_reslim_cfg import reslim_landsat
-from ows_refactored.surface_reflectance.band_sr_cfg import bands_ls
-from ows_refactored.surface_reflectance.style_sr_cfg import styles_sr_list
+from ows_refactored.surface_reflectance.band_sr_cfg import bands_lsc2_sr
+from ows_refactored.surface_reflectance.style_sr_cfg import styles_lsc2_sr_list
 
 layers = {
     "title": "Landsat",
@@ -11,14 +11,14 @@ layers = {
                         based projection.""",
     "layers": [
         {
-            "title": "Surface Reflectance Landsat 8 (USGS Collection 1)",
-            "name": "ls8_usgs_sr_scene",
+            "title": "Surface Reflectance Landsat 8 (USGS Collection 2)",
+            "name": "ls8_sr",
             "abstract": """
 Surface reflectance is the fraction of incoming solar radiation that is reflected from Earth's surface. Variations in satellite measured radiance due to atmospheric properties have been corrected for, so images acquired over the same area at different times are comparable and can be used readily to detect changes on Earth’s surface.
 
-DE Africa contains Landsat Collection 1, Level 2 surface reflectance products over five countries (Tanzania, Senegal, Sierra Leone, Ghana, and Kenya). Landsat Collection 1 consists of products generated from the Landsat 8 Operational Land Imager (OLI) / Thermal Infrared Sensor (TIRS), Landsat 7 Enhanced Thematic Mapper Plus (ETM+), Landsat 4-5 Thematic Mapper (TM), and Landsat 1-5 Multispectral Scanner (MSS) instruments. The implementation of collections ensures consistent and known radiometric and geometric quality through time and across instruments and improves control in the calibration and processing parameters.
+DE Africa contains Landsat Collection 2, Level 2 surface reflectance products over all Africa. Landsat Collection 2 consists of products generated from the Landsat 8 Operational Land Imager (OLI) / Thermal Infrared Sensor (TIRS), Landsat 7 Enhanced Thematic Mapper Plus (ETM+), Landsat 4-5 Thematic Mapper (TM), and Landsat 1-5 Multispectral Scanner (MSS) instruments. The implementation of collections ensures consistent and known radiometric and geometric quality through time and across instruments and improves control in the calibration and processing parameters.
 
-This product has a spatial resolution of 30 m and a temporal coverage of 2013 to 2019. The surface reflectance values are scaled to be between 0 and 10,000.
+This product has a spatial resolution of 30 m and a temporal coverage of 2013 to 2019. The surface reflectance values are scaled to be between 1 and 65,455.
 
 It is provided by United States Geological Survey (USGS).
 
@@ -26,8 +26,8 @@ For more information on the Landsat surface reflectance product, see https://www
 
 This product is accessible through OGC Web Service (https://ows.digitalearth.africa/), for analysis in DE Africa Sandbox JupyterLab (https://github.com/digitalearthafrica/deafrica-sandbox-notebooks/wiki) and for direct download from AWS S3 (https://data.digitalearth.africa/).
 """,
-            "product_name": "ls8_usgs_sr_scene",
-            "bands": bands_ls,
+            "product_name": "ls8_sr",
+            "bands": bands_lsc2_sr,
             "resource_limits": reslim_landsat,
             "image_processing": {
                 "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
@@ -42,18 +42,18 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
             },
             "styling": {
                 "default_style": "simple_rgb",
-                "styles": styles_sr_list,
+                "styles": styles_lsc2_sr_list,
             },
         },
         {
-            "title": "Surface Reflectance Landsat 7 (USGS Collection 1)",
-            "name": "ls7_usgs_sr_scene",
+            "title": "Surface Reflectance Landsat 7 (USGS Collection 2)",
+            "name": "ls7_sr",
             "abstract": """
 Surface reflectance is the fraction of incoming solar radiation that is reflected from Earth's surface. Variations in satellite measured radiance due to atmospheric properties have been corrected for so images acquired over the same area at different times are comparable and can be used readily to detect changes on Earth’s surface.
 
-DE Africa contains Landsat Collection 1, Level 2 surface reflectance products over five countries (Tanzania, Senegal, Sierra Leone, Ghana, and Kenya). Landsat Collection 1 consists of products generated from the Landsat 8 Operational Land Imager (OLI) / Thermal Infrared Sensor (TIRS), Landsat 7 Enhanced Thematic Mapper Plus (ETM+), Landsat 4-5 Thematic Mapper (TM), and Landsat 1-5 Multispectral Scanner (MSS) instruments. The implementation of collections ensures consistent and known radiometric and geometric quality through time and across instruments and improves control in the calibration and processing parameters.
+DE Africa contains Landsat Collection 2, Level 2 surface reflectance products over all Africa. Landsat Collection 2 consists of products generated from the Landsat 8 Operational Land Imager (OLI) / Thermal Infrared Sensor (TIRS), Landsat 7 Enhanced Thematic Mapper Plus (ETM+), Landsat 4-5 Thematic Mapper (TM), and Landsat 1-5 Multispectral Scanner (MSS) instruments. The implementation of collections ensures consistent and known radiometric and geometric quality through time and across instruments and improves control in the calibration and processing parameters.
 
-This product has a spatial resolution of 30 m and a temporal coverage of 1999 to 2019. The surface reflectance values are scaled to be between 0 and 10,000.
+This product has a spatial resolution of 30 m and a temporal coverage of 1999 to 2019. The surface reflectance values are scaled to be between 1 and 65,455.
 
 It is provided by United States Geological Survey (USGS).
 
@@ -61,8 +61,8 @@ For more information on the Landsat surface reflectance product, see https://www
 
 This product is accessible through OGC Web Service (https://ows.digitalearth.africa/), for analysis in DE Africa Sandbox JupyterLab (https://github.com/digitalearthafrica/deafrica-sandbox-notebooks/wiki) and for direct download from AWS S3 (https://data.digitalearth.africa/).
 """,
-            "product_name": "ls7_usgs_sr_scene",
-            "bands": bands_ls,
+            "product_name": "ls7_sr",
+            "bands": bands_lsc2_sr,
             "resource_limits": reslim_landsat,
             "image_processing": {
                 "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
@@ -77,18 +77,18 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
             },
             "styling": {
                 "default_style": "simple_rgb",
-                "styles": styles_sr_list,
+                "styles": styles_lsc2_sr_list,
             },
         },
         {
-            "title": "Surface Reflectance Landsat 5 (USGS Collection 1)",
-            "name": "ls5_usgs_sr_scene",
+            "title": "Surface Reflectance Landsat 5 (USGS Collection 2)",
+            "name": "ls5_sr",
             "abstract": """
 Surface reflectance is the fraction of incoming solar radiation that is reflected from Earth's surface. Variations in satellite measured radiance due to atmospheric properties have been corrected for so images acquired over the same area at different times are comparable and can be used readily to detect changes on Earth’s surface.
 
-DE Africa contains Landsat Collection 1, Level 2 surface reflectance products over five countries (Tanzania, Senegal, Sierra Leone, Ghana, and Kenya). Landsat Collection 1 consists of products generated from the Landsat 8 Operational Land Imager (OLI) / Thermal Infrared Sensor (TIRS), Landsat 7 Enhanced Thematic Mapper Plus (ETM+), Landsat 4-5 Thematic Mapper (TM), and Landsat 1-5 Multispectral Scanner (MSS) instruments. The implementation of collections ensures consistent and known radiometric and geometric quality through time and across instruments and improves control in the calibration and processing parameters.
+DE Africa contains Landsat Collection 2, Level 2 surface reflectance products over all Africa. Landsat Collection 2 consists of products generated from the Landsat 8 Operational Land Imager (OLI) / Thermal Infrared Sensor (TIRS), Landsat 7 Enhanced Thematic Mapper Plus (ETM+), Landsat 4-5 Thematic Mapper (TM), and Landsat 1-5 Multispectral Scanner (MSS) instruments. The implementation of collections ensures consistent and known radiometric and geometric quality through time and across instruments and improves control in the calibration and processing parameters.
 
-This product has a spatial resolution of 30 m and a temporal coverage of 1984 to 2011. The surface reflectance values are scaled to be between 0 and 10,000.
+This product has a spatial resolution of 30 m and a temporal coverage of 1984 to 2011. The surface reflectance values are scaled to be between 1 and 65,455.
 
 It is provided by United States Geological Survey (USGS).
 
@@ -96,8 +96,8 @@ For more information on the Landsat surface reflectance product, see https://www
 
 This product is accessible through OGC Web Service (https://ows.digitalearth.africa/), for analysis in DE Africa Sandbox JupyterLab (https://github.com/digitalearthafrica/deafrica-sandbox-notebooks/wiki) and for direct download from AWS S3 (https://data.digitalearth.africa/).
 """,
-            "product_name": "ls5_usgs_sr_scene",
-            "bands": bands_ls,
+            "product_name": "ls5_sr",
+            "bands": bands_lsc2_sr,
             "resource_limits": reslim_landsat,
             "image_processing": {
                 "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
@@ -112,7 +112,7 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
             },
             "styling": {
                 "default_style": "simple_rgb",
-                "styles": styles_sr_list,
+                "styles": styles_lsc2_sr_list,
             },
         },
     ],

--- a/services/ows_refactored/surface_reflectance/ows_sr_cfg.py
+++ b/services/ows_refactored/surface_reflectance/ows_sr_cfg.py
@@ -1,4 +1,4 @@
-# This config file is for Oregon - Production 
+# This config file is for Oregon - Production
 from ows_refactored.common.ows_reslim_cfg import reslim_landsat
 from ows_refactored.surface_reflectance.band_sr_cfg import bands_ls
 from ows_refactored.surface_reflectance.style_sr_cfg import styles_sr_list

--- a/services/ows_refactored/surface_reflectance/ows_sr_cfg.py
+++ b/services/ows_refactored/surface_reflectance/ows_sr_cfg.py
@@ -1,6 +1,7 @@
+# This config file is for Oregon - Production 
 from ows_refactored.common.ows_reslim_cfg import reslim_landsat
-from ows_refactored.surface_reflectance.band_sr_cfg import bands_lsc2_sr
-from ows_refactored.surface_reflectance.style_sr_cfg import styles_lsc2_sr_list
+from ows_refactored.surface_reflectance.band_sr_cfg import bands_ls
+from ows_refactored.surface_reflectance.style_sr_cfg import styles_sr_list
 
 layers = {
     "title": "Landsat",
@@ -11,25 +12,23 @@ layers = {
                         based projection.""",
     "layers": [
         {
-            "title": "Surface Reflectance Landsat 8 (USGS Collection 2)",
-            "name": "ls8_sr",
+            "title": "Surface Reflectance Landsat 8 (USGS Collection 1)",
+            "name": "ls8_usgs_sr_scene",
             "abstract": """
 Surface reflectance is the fraction of incoming solar radiation that is reflected from Earth's surface. Variations in satellite measured radiance due to atmospheric properties have been corrected for, so images acquired over the same area at different times are comparable and can be used readily to detect changes on Earth’s surface.
 
-DE Africa provides access to Landsat Collection 2 Level-2 Surface Reflectance products over Africa. USGS Landsat Collection 2 offers improved processing, geometric accuracy, and radiometric calibration compared to previous Collection 1 products. The Level-2 products are endorsed by the Committee on Earth Observation Satellites (CEOS) to be Analysis Ready Data for Land (CARD4L)-compliant.
+DE Africa contains Landsat Collection 1, Level 2 surface reflectance products over five countries (Tanzania, Senegal, Sierra Leone, Ghana, and Kenya). Landsat Collection 1 consists of products generated from the Landsat 8 Operational Land Imager (OLI) / Thermal Infrared Sensor (TIRS), Landsat 7 Enhanced Thematic Mapper Plus (ETM+), Landsat 4-5 Thematic Mapper (TM), and Landsat 1-5 Multispectral Scanner (MSS) instruments. The implementation of collections ensures consistent and known radiometric and geometric quality through time and across instruments and improves control in the calibration and processing parameters.
 
-More techincal information about the Landsat Surface Reflectance product can be found in the User Guide (https://docs.digitalearthafrica.org/en/latest/data_specs/Landsat_C2_SR_specs.html).
+This product has a spatial resolution of 30 m and a temporal coverage of 2013 to 2019. The surface reflectance values are scaled to be between 0 and 10,000.
 
-Landsat 8 product has a spatial resolution of 30 m and a temporal coverage of 2013 to present.
+It is provided by United States Geological Survey (USGS).
 
-Landsat Level- 2 Surface Reflectance Science Product courtesy of the U.S. Geological Survey.
-
-For more information on Landsat products, see https://www.usgs.gov/core-science-systems/nli/landsat/landsat-collection-2-level-2-science-products.
+For more information on the Landsat surface reflectance product, see https://www.usgs.gov/land-resources/nli/landsat/landsat-surface-reflectance
 
 This product is accessible through OGC Web Service (https://ows.digitalearth.africa/), for analysis in DE Africa Sandbox JupyterLab (https://github.com/digitalearthafrica/deafrica-sandbox-notebooks/wiki) and for direct download from AWS S3 (https://data.digitalearth.africa/).
 """,
-            "product_name": "ls8_sr",
-            "bands": bands_lsc2_sr,
+            "product_name": "ls8_usgs_sr_scene",
+            "bands": bands_ls,
             "resource_limits": reslim_landsat,
             "image_processing": {
                 "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
@@ -44,29 +43,27 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
             },
             "styling": {
                 "default_style": "simple_rgb",
-                "styles": styles_lsc2_sr_list,
+                "styles": styles_sr_list,
             },
         },
         {
-            "title": "Surface Reflectance Landsat 7 (USGS Collection 2)",
-            "name": "ls7_sr",
+            "title": "Surface Reflectance Landsat 7 (USGS Collection 1)",
+            "name": "ls7_usgs_sr_scene",
             "abstract": """
-Surface reflectance is the fraction of incoming solar radiation that is reflected from Earth's surface. Variations in satellite measured radiance due to atmospheric properties have been corrected for, so images acquired over the same area at different times are comparable and can be used readily to detect changes on Earth’s surface.
+Surface reflectance is the fraction of incoming solar radiation that is reflected from Earth's surface. Variations in satellite measured radiance due to atmospheric properties have been corrected for so images acquired over the same area at different times are comparable and can be used readily to detect changes on Earth’s surface.
 
-DE Africa provides access to Landsat Collection 2 Level-2 Surface Reflectance products over Africa. USGS Landsat Collection 2 offers improved processing, geometric accuracy, and radiometric calibration compared to previous Collection 1 products. The Level-2 products are endorsed by the Committee on Earth Observation Satellites (CEOS) to be Analysis Ready Data for Land (CARD4L)-compliant.
+DE Africa contains Landsat Collection 1, Level 2 surface reflectance products over five countries (Tanzania, Senegal, Sierra Leone, Ghana, and Kenya). Landsat Collection 1 consists of products generated from the Landsat 8 Operational Land Imager (OLI) / Thermal Infrared Sensor (TIRS), Landsat 7 Enhanced Thematic Mapper Plus (ETM+), Landsat 4-5 Thematic Mapper (TM), and Landsat 1-5 Multispectral Scanner (MSS) instruments. The implementation of collections ensures consistent and known radiometric and geometric quality through time and across instruments and improves control in the calibration and processing parameters.
 
-More techincal information about the Landsat Surface Reflectance product can be found in the User Guide (https://docs.digitalearthafrica.org/en/latest/data_specs/Landsat_C2_SR_specs.html).
+This product has a spatial resolution of 30 m and a temporal coverage of 1999 to 2019. The surface reflectance values are scaled to be between 0 and 10,000.
 
-Landsat 7 product has a spatial resolution of 30 m and a temporal coverage of 1999 to present.
+It is provided by United States Geological Survey (USGS).
 
-Landsat Level- 2 Surface Reflectance Science Product courtesy of the U.S. Geological Survey.
-
-For more information on Landsat products, see https://www.usgs.gov/core-science-systems/nli/landsat/landsat-collection-2-level-2-science-products.
+For more information on the Landsat surface reflectance product, see https://www.usgs.gov/land-resources/nli/landsat/landsat-surface-reflectance
 
 This product is accessible through OGC Web Service (https://ows.digitalearth.africa/), for analysis in DE Africa Sandbox JupyterLab (https://github.com/digitalearthafrica/deafrica-sandbox-notebooks/wiki) and for direct download from AWS S3 (https://data.digitalearth.africa/).
 """,
-            "product_name": "ls7_sr",
-            "bands": bands_lsc2_sr,
+            "product_name": "ls7_usgs_sr_scene",
+            "bands": bands_ls,
             "resource_limits": reslim_landsat,
             "image_processing": {
                 "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
@@ -81,29 +78,27 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
             },
             "styling": {
                 "default_style": "simple_rgb",
-                "styles": styles_lsc2_sr_list,
+                "styles": styles_sr_list,
             },
         },
         {
-            "title": "Surface Reflectance Landsat 5 (USGS Collection 2)",
-            "name": "ls5_sr",
+            "title": "Surface Reflectance Landsat 5 (USGS Collection 1)",
+            "name": "ls5_usgs_sr_scene",
             "abstract": """
-Surface reflectance is the fraction of incoming solar radiation that is reflected from Earth's surface. Variations in satellite measured radiance due to atmospheric properties have been corrected for, so images acquired over the same area at different times are comparable and can be used readily to detect changes on Earth’s surface.
+Surface reflectance is the fraction of incoming solar radiation that is reflected from Earth's surface. Variations in satellite measured radiance due to atmospheric properties have been corrected for so images acquired over the same area at different times are comparable and can be used readily to detect changes on Earth’s surface.
 
-DE Africa provides access to Landsat Collection 2 Level-2 Surface Reflectance products over Africa. USGS Landsat Collection 2 offers improved processing, geometric accuracy, and radiometric calibration compared to previous Collection 1 products. The Level-2 products are endorsed by the Committee on Earth Observation Satellites (CEOS) to be Analysis Ready Data for Land (CARD4L)-compliant.
+DE Africa contains Landsat Collection 1, Level 2 surface reflectance products over five countries (Tanzania, Senegal, Sierra Leone, Ghana, and Kenya). Landsat Collection 1 consists of products generated from the Landsat 8 Operational Land Imager (OLI) / Thermal Infrared Sensor (TIRS), Landsat 7 Enhanced Thematic Mapper Plus (ETM+), Landsat 4-5 Thematic Mapper (TM), and Landsat 1-5 Multispectral Scanner (MSS) instruments. The implementation of collections ensures consistent and known radiometric and geometric quality through time and across instruments and improves control in the calibration and processing parameters.
 
-More techincal information about the Landsat Surface Reflectance product can be found in the User Guide (https://docs.digitalearthafrica.org/en/latest/data_specs/Landsat_C2_SR_specs.html).
+This product has a spatial resolution of 30 m and a temporal coverage of 1984 to 2011. The surface reflectance values are scaled to be between 0 and 10,000.
 
-Landsat 5 product has a spatial resolution of 30 m and a temporal coverage of 1984 to 2012.
+It is provided by United States Geological Survey (USGS).
 
-Landsat Level- 2 Surface Reflectance Science Product courtesy of the U.S. Geological Survey.
-
-For more information on Landsat products, see https://www.usgs.gov/core-science-systems/nli/landsat/landsat-collection-2-level-2-science-products.
+For more information on the Landsat surface reflectance product, see https://www.usgs.gov/land-resources/nli/landsat/landsat-surface-reflectance
 
 This product is accessible through OGC Web Service (https://ows.digitalearth.africa/), for analysis in DE Africa Sandbox JupyterLab (https://github.com/digitalearthafrica/deafrica-sandbox-notebooks/wiki) and for direct download from AWS S3 (https://data.digitalearth.africa/).
 """,
-            "product_name": "ls5_sr",
-            "bands": bands_lsc2_sr,
+            "product_name": "ls5_usgs_sr_scene",
+            "bands": bands_ls,
             "resource_limits": reslim_landsat,
             "image_processing": {
                 "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
@@ -118,7 +113,7 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
             },
             "styling": {
                 "default_style": "simple_rgb",
-                "styles": styles_lsc2_sr_list,
+                "styles": styles_sr_list,
             },
         },
     ],

--- a/services/ows_refactored/surface_reflectance/ows_sr_cfg.py
+++ b/services/ows_refactored/surface_reflectance/ows_sr_cfg.py
@@ -14,13 +14,13 @@ layers = {
             "title": "Surface Reflectance Landsat 8 (USGS Collection 2)",
             "name": "ls8_sr",
             "abstract": """
-Surface reflectance is the fraction of incoming solar radiation that is reflected from Earth's surface. Variations in satellite measured radiance due to atmospheric properties have been corrected for, so images acquired over the same area at different times are comparable and can be used readily to detect changes on Earth’s surface. 
+Surface reflectance is the fraction of incoming solar radiation that is reflected from Earth's surface. Variations in satellite measured radiance due to atmospheric properties have been corrected for, so images acquired over the same area at different times are comparable and can be used readily to detect changes on Earth’s surface.
 
-DE Africa provides access to Landsat Collection 2 Level-2 Surface Reflectance products over Africa. USGS Landsat Collection 2 offers improved processing, geometric accuracy, and radiometric calibration compared to previous Collection 1 products. The Level-2 products are endorsed by the Committee on Earth Observation Satellites (CEOS) to be Analysis Ready Data for Land (CARD4L)-compliant. 
+DE Africa provides access to Landsat Collection 2 Level-2 Surface Reflectance products over Africa. USGS Landsat Collection 2 offers improved processing, geometric accuracy, and radiometric calibration compared to previous Collection 1 products. The Level-2 products are endorsed by the Committee on Earth Observation Satellites (CEOS) to be Analysis Ready Data for Land (CARD4L)-compliant.
 
 More techincal information about the Landsat Surface Reflectance product can be found in the User Guide (https://docs.digitalearthafrica.org/en/latest/data_specs/Landsat_C2_SR_specs.html).
 
-Landsat 8 product has a spatial resolution of 30 m and a temporal coverage of 2013 to present. 
+Landsat 8 product has a spatial resolution of 30 m and a temporal coverage of 2013 to present.
 
 Landsat Level- 2 Surface Reflectance Science Product courtesy of the U.S. Geological Survey.
 
@@ -51,9 +51,9 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
             "title": "Surface Reflectance Landsat 7 (USGS Collection 2)",
             "name": "ls7_sr",
             "abstract": """
-Surface reflectance is the fraction of incoming solar radiation that is reflected from Earth's surface. Variations in satellite measured radiance due to atmospheric properties have been corrected for, so images acquired over the same area at different times are comparable and can be used readily to detect changes on Earth’s surface. 
+Surface reflectance is the fraction of incoming solar radiation that is reflected from Earth's surface. Variations in satellite measured radiance due to atmospheric properties have been corrected for, so images acquired over the same area at different times are comparable and can be used readily to detect changes on Earth’s surface.
 
-DE Africa provides access to Landsat Collection 2 Level-2 Surface Reflectance products over Africa. USGS Landsat Collection 2 offers improved processing, geometric accuracy, and radiometric calibration compared to previous Collection 1 products. The Level-2 products are endorsed by the Committee on Earth Observation Satellites (CEOS) to be Analysis Ready Data for Land (CARD4L)-compliant. 
+DE Africa provides access to Landsat Collection 2 Level-2 Surface Reflectance products over Africa. USGS Landsat Collection 2 offers improved processing, geometric accuracy, and radiometric calibration compared to previous Collection 1 products. The Level-2 products are endorsed by the Committee on Earth Observation Satellites (CEOS) to be Analysis Ready Data for Land (CARD4L)-compliant.
 
 More techincal information about the Landsat Surface Reflectance product can be found in the User Guide (https://docs.digitalearthafrica.org/en/latest/data_specs/Landsat_C2_SR_specs.html).
 
@@ -88,9 +88,9 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
             "title": "Surface Reflectance Landsat 5 (USGS Collection 2)",
             "name": "ls5_sr",
             "abstract": """
-Surface reflectance is the fraction of incoming solar radiation that is reflected from Earth's surface. Variations in satellite measured radiance due to atmospheric properties have been corrected for, so images acquired over the same area at different times are comparable and can be used readily to detect changes on Earth’s surface. 
+Surface reflectance is the fraction of incoming solar radiation that is reflected from Earth's surface. Variations in satellite measured radiance due to atmospheric properties have been corrected for, so images acquired over the same area at different times are comparable and can be used readily to detect changes on Earth’s surface.
 
-DE Africa provides access to Landsat Collection 2 Level-2 Surface Reflectance products over Africa. USGS Landsat Collection 2 offers improved processing, geometric accuracy, and radiometric calibration compared to previous Collection 1 products. The Level-2 products are endorsed by the Committee on Earth Observation Satellites (CEOS) to be Analysis Ready Data for Land (CARD4L)-compliant. 
+DE Africa provides access to Landsat Collection 2 Level-2 Surface Reflectance products over Africa. USGS Landsat Collection 2 offers improved processing, geometric accuracy, and radiometric calibration compared to previous Collection 1 products. The Level-2 products are endorsed by the Committee on Earth Observation Satellites (CEOS) to be Analysis Ready Data for Land (CARD4L)-compliant.
 
 More techincal information about the Landsat Surface Reflectance product can be found in the User Guide (https://docs.digitalearthafrica.org/en/latest/data_specs/Landsat_C2_SR_specs.html).
 

--- a/services/ows_refactored/surface_reflectance/ows_sr_cfg.py
+++ b/services/ows_refactored/surface_reflectance/ows_sr_cfg.py
@@ -14,15 +14,17 @@ layers = {
             "title": "Surface Reflectance Landsat 8 (USGS Collection 2)",
             "name": "ls8_sr",
             "abstract": """
-Surface reflectance is the fraction of incoming solar radiation that is reflected from Earth's surface. Variations in satellite measured radiance due to atmospheric properties have been corrected for, so images acquired over the same area at different times are comparable and can be used readily to detect changes on Earth’s surface.
+Surface reflectance is the fraction of incoming solar radiation that is reflected from Earth's surface. Variations in satellite measured radiance due to atmospheric properties have been corrected for, so images acquired over the same area at different times are comparable and can be used readily to detect changes on Earth’s surface. 
 
-DE Africa contains Landsat Collection 2, Level 2 surface reflectance products over all Africa. Landsat Collection 2 consists of products generated from the Landsat 8 Operational Land Imager (OLI) / Thermal Infrared Sensor (TIRS), Landsat 7 Enhanced Thematic Mapper Plus (ETM+), Landsat 4-5 Thematic Mapper (TM), and Landsat 1-5 Multispectral Scanner (MSS) instruments. The implementation of collections ensures consistent and known radiometric and geometric quality through time and across instruments and improves control in the calibration and processing parameters.
+DE Africa provides access to Landsat Collection 2 Level-2 Surface Reflectance products over Africa. USGS Landsat Collection 2 offers improved processing, geometric accuracy, and radiometric calibration compared to previous Collection 1 products. The Level-2 products are endorsed by the Committee on Earth Observation Satellites (CEOS) to be Analysis Ready Data for Land (CARD4L)-compliant. 
 
-This product has a spatial resolution of 30 m and a temporal coverage of 2013 to 2019. The surface reflectance values are scaled to be between 1 and 65,455.
+More techincal information about the Landsat Surface Reflectance product can be found in the User Guide (https://docs.digitalearthafrica.org/en/latest/data_specs/Landsat_C2_SR_specs.html).
 
-It is provided by United States Geological Survey (USGS).
+Landsat 8 product has a spatial resolution of 30 m and a temporal coverage of 2013 to present. 
 
-For more information on the Landsat surface reflectance product, see https://www.usgs.gov/land-resources/nli/landsat/landsat-surface-reflectance
+Landsat Level- 2 Surface Reflectance Science Product courtesy of the U.S. Geological Survey.
+
+For more information on Landsat products, see https://www.usgs.gov/core-science-systems/nli/landsat/landsat-collection-2-level-2-science-products.
 
 This product is accessible through OGC Web Service (https://ows.digitalearth.africa/), for analysis in DE Africa Sandbox JupyterLab (https://github.com/digitalearthafrica/deafrica-sandbox-notebooks/wiki) and for direct download from AWS S3 (https://data.digitalearth.africa/).
 """,
@@ -49,15 +51,17 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
             "title": "Surface Reflectance Landsat 7 (USGS Collection 2)",
             "name": "ls7_sr",
             "abstract": """
-Surface reflectance is the fraction of incoming solar radiation that is reflected from Earth's surface. Variations in satellite measured radiance due to atmospheric properties have been corrected for so images acquired over the same area at different times are comparable and can be used readily to detect changes on Earth’s surface.
+Surface reflectance is the fraction of incoming solar radiation that is reflected from Earth's surface. Variations in satellite measured radiance due to atmospheric properties have been corrected for, so images acquired over the same area at different times are comparable and can be used readily to detect changes on Earth’s surface. 
 
-DE Africa contains Landsat Collection 2, Level 2 surface reflectance products over all Africa. Landsat Collection 2 consists of products generated from the Landsat 8 Operational Land Imager (OLI) / Thermal Infrared Sensor (TIRS), Landsat 7 Enhanced Thematic Mapper Plus (ETM+), Landsat 4-5 Thematic Mapper (TM), and Landsat 1-5 Multispectral Scanner (MSS) instruments. The implementation of collections ensures consistent and known radiometric and geometric quality through time and across instruments and improves control in the calibration and processing parameters.
+DE Africa provides access to Landsat Collection 2 Level-2 Surface Reflectance products over Africa. USGS Landsat Collection 2 offers improved processing, geometric accuracy, and radiometric calibration compared to previous Collection 1 products. The Level-2 products are endorsed by the Committee on Earth Observation Satellites (CEOS) to be Analysis Ready Data for Land (CARD4L)-compliant. 
 
-This product has a spatial resolution of 30 m and a temporal coverage of 1999 to 2019. The surface reflectance values are scaled to be between 1 and 65,455.
+More techincal information about the Landsat Surface Reflectance product can be found in the User Guide (https://docs.digitalearthafrica.org/en/latest/data_specs/Landsat_C2_SR_specs.html).
 
-It is provided by United States Geological Survey (USGS).
+Landsat 7 product has a spatial resolution of 30 m and a temporal coverage of 1999 to present.
 
-For more information on the Landsat surface reflectance product, see https://www.usgs.gov/land-resources/nli/landsat/landsat-surface-reflectance
+Landsat Level- 2 Surface Reflectance Science Product courtesy of the U.S. Geological Survey.
+
+For more information on Landsat products, see https://www.usgs.gov/core-science-systems/nli/landsat/landsat-collection-2-level-2-science-products.
 
 This product is accessible through OGC Web Service (https://ows.digitalearth.africa/), for analysis in DE Africa Sandbox JupyterLab (https://github.com/digitalearthafrica/deafrica-sandbox-notebooks/wiki) and for direct download from AWS S3 (https://data.digitalearth.africa/).
 """,
@@ -84,15 +88,17 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
             "title": "Surface Reflectance Landsat 5 (USGS Collection 2)",
             "name": "ls5_sr",
             "abstract": """
-Surface reflectance is the fraction of incoming solar radiation that is reflected from Earth's surface. Variations in satellite measured radiance due to atmospheric properties have been corrected for so images acquired over the same area at different times are comparable and can be used readily to detect changes on Earth’s surface.
+Surface reflectance is the fraction of incoming solar radiation that is reflected from Earth's surface. Variations in satellite measured radiance due to atmospheric properties have been corrected for, so images acquired over the same area at different times are comparable and can be used readily to detect changes on Earth’s surface. 
 
-DE Africa contains Landsat Collection 2, Level 2 surface reflectance products over all Africa. Landsat Collection 2 consists of products generated from the Landsat 8 Operational Land Imager (OLI) / Thermal Infrared Sensor (TIRS), Landsat 7 Enhanced Thematic Mapper Plus (ETM+), Landsat 4-5 Thematic Mapper (TM), and Landsat 1-5 Multispectral Scanner (MSS) instruments. The implementation of collections ensures consistent and known radiometric and geometric quality through time and across instruments and improves control in the calibration and processing parameters.
+DE Africa provides access to Landsat Collection 2 Level-2 Surface Reflectance products over Africa. USGS Landsat Collection 2 offers improved processing, geometric accuracy, and radiometric calibration compared to previous Collection 1 products. The Level-2 products are endorsed by the Committee on Earth Observation Satellites (CEOS) to be Analysis Ready Data for Land (CARD4L)-compliant. 
 
-This product has a spatial resolution of 30 m and a temporal coverage of 1984 to 2011. The surface reflectance values are scaled to be between 1 and 65,455.
+More techincal information about the Landsat Surface Reflectance product can be found in the User Guide (https://docs.digitalearthafrica.org/en/latest/data_specs/Landsat_C2_SR_specs.html).
 
-It is provided by United States Geological Survey (USGS).
+Landsat 5 product has a spatial resolution of 30 m and a temporal coverage of 1984 to 2012.
 
-For more information on the Landsat surface reflectance product, see https://www.usgs.gov/land-resources/nli/landsat/landsat-surface-reflectance
+Landsat Level- 2 Surface Reflectance Science Product courtesy of the U.S. Geological Survey.
+
+For more information on Landsat products, see https://www.usgs.gov/core-science-systems/nli/landsat/landsat-collection-2-level-2-science-products.
 
 This product is accessible through OGC Web Service (https://ows.digitalearth.africa/), for analysis in DE Africa Sandbox JupyterLab (https://github.com/digitalearthafrica/deafrica-sandbox-notebooks/wiki) and for direct download from AWS S3 (https://data.digitalearth.africa/).
 """,

--- a/services/ows_refactored/surface_reflectance/style_sr_cfg.py
+++ b/services/ows_refactored/surface_reflectance/style_sr_cfg.py
@@ -759,3 +759,170 @@ styles_sr_list = [
     style_sentinel_pure_swir1,
     style_sentinel_pure_swir2,
 ]
+
+# styles for Landsat C2
+# Band wavelengths have been removed as they differ
+# between LS5, 7 and 8
+# Scale range is set as per Collection 1, but scaled to
+# 65455 instead of 10000
+
+style_lsc2_sr_simple_rgb = {
+    "name": "simple_rgb",
+    "title": "True colour - RGB",
+    "abstract": "True-colour image, using the red, green and blue bands",
+    "components": {
+        "red": {"red": 1.0},
+        "green": {"green": 1.0}, 
+        "blue": {"blue": 1.0}
+    },
+    "scale_range": [1.0, 19636.0],
+}
+
+style_lsc2_sr_irg = {
+    "name": "infrared_green",
+    "title": "False colour - SWIR, NIR, Green",
+    "abstract": "False colour image with SWIR1->Red, NIR->Green, and Green->Blue",
+    "components": {
+        "red": {"swir_1": 1.0},
+        "green": {"nir": 1.0},
+        "blue": {"green": 1.0},
+    },
+    "scale_range": [1.0, 19636.0],
+}
+
+style_lsc2_sr_ndvi = {
+    "name": "ndvi",
+    "title": "NDVI - Red, NIR",
+    "abstract": "Normalised Difference Vegetation Index - a derived index that correlates well with the existence of vegetation",
+    "index_function": {
+        "function": "datacube_ows.band_utils.norm_diff",
+        "mapped_bands": True,
+        "kwargs": {"band1": "nir", "band2": "red"},
+    },
+    "needed_bands": ["red", "nir"],
+    "color_ramp": [
+        {"value": -0.0, "color": "#8F3F20", "alpha": 0.0},
+        {"value": 0.0, "color": "#8F3F20", "alpha": 1.0},
+        {"value": 0.1, "color": "#A35F18"},
+        {"value": 0.2, "color": "#B88512"},
+        {"value": 0.3, "color": "#CEAC0E"},
+        {"value": 0.4, "color": "#E5D609"},
+        {"value": 0.5, "color": "#FFFF0C"},
+        {"value": 0.6, "color": "#C3DE09"},
+        {"value": 0.7, "color": "#88B808"},
+        {"value": 0.8, "color": "#529400"},
+        {"value": 0.9, "color": "#237100"},
+        {"value": 1.0, "color": "#114D04"},
+    ],
+    "legend": legend_idx_0_1_5ticks,
+}
+
+style_lsc2_sr_ndwi = {
+    "name": "ndwi",
+    "title": "NDWI - Green, NIR",
+    "abstract": "Normalised Difference Water Index - a derived index that correlates well with the existence of water (McFeeters 1996)",
+    "index_function": {
+        "function": "datacube_ows.band_utils.norm_diff",
+        "mapped_bands": True,
+        "kwargs": {"band1": "green", "band2": "nir"},
+    },
+    "needed_bands": ["green", "nir"],
+    "color_ramp": [
+        {"value": -0.1, "color": "#f7fbff", "alpha": 0.0},
+        {"value": 0.0, "color": "#d8e7f5", "legend": {"prefix": "<"}},
+        {"value": 0.1, "color": "#b0d2e8"},
+        {"value": 0.2, "color": "#73b3d8", "legend": {}},
+        {"value": 0.3, "color": "#3e8ec4"},
+        {"value": 0.4, "color": "#1563aa", "legend": {}},
+        {"value": 0.5, "color": "#08306b", "legend": {"prefix": ">"}},
+    ],
+    "legend": {
+        "begin": "0.0",
+        "end": "0.5",
+        "decimal_places": 1,
+        "ticks": ["0.0", "0.2", "0.4", "0.5"],
+        "tick_labels": {
+            "0.0": {"prefix": "<"},
+            "0.2": {"label": "0.2"},
+            "0.4": {"label": "0.4"},
+            "0.5": {"prefix": ">"},
+        },
+    },
+}
+
+style_lsc2_sr_pure_blue = {
+    "name": "blue",
+    "title": "Blue",
+    "abstract": "Blue band",
+    "components": {"red": {"blue": 1.0}, "green": {"blue": 1.0}, "blue": {"blue": 1.0}},
+    "scale_range": [1.0, 19636.0],
+}
+
+style_lsc2_sr_pure_green = {
+    "name": "green",
+    "title": "Green",
+    "abstract": "Green band",
+    "components": {
+        "red": {"green": 1.0},
+        "green": {"green": 1.0},
+        "blue": {"green": 1.0},
+    },
+    "scale_range": [1.0, 19636.0],
+}
+
+style_lsc2_sr_pure_red = {
+    "name": "red",
+    "title": "Red",
+    "abstract": "Red band",
+    "components": {"red": {"red": 1.0}, "green": {"red": 1.0}, "blue": {"red": 1.0}
+    },
+    "scale_range": [1.0, 19636.0],
+}
+
+style_lsc2_sr_pure_nir = {
+    "name": "nir",
+    "title": "Near Infrared (NIR)",
+    "abstract": "Near infra-red band",
+    "components": {"red": {"nir": 1.0}, "green": {"nir": 1.0}, "blue": {"nir": 1.0}},
+    "scale_range": [1.0, 19636.0],
+}
+
+style_lsc2_sr_pure_swir1 = {
+    "name": "swir1",
+    "title": "Shortwave Infrared 1 (SWIR1)",
+    "abstract": "Shortwave infrared band 1",
+    "components": {
+        "red": {"swir1": 1.0},
+        "green": {"swir1": 1.0},
+        "blue": {"swir1": 1.0},
+    },
+    "scale_range": [1.0, 19636.0],
+}
+
+style_lsc2_sr_pure_swir2 = {
+    "name": "swir2",
+    "title": "Shortwave Infrared 2 (SWIR2)",
+    "abstract": "Shortwave infrared band 2",
+    "components": {
+        "red": {"swir2": 1.0},
+        "green": {"swir2": 1.0},
+        "blue": {"swir2": 1.0},
+    },
+    "scale_range": [1.0, 19636.0],
+}
+
+styles_lsc2_sr_list = [
+    style_lsc2_sr_simple_rgb,
+    style_lsc2_sr_irg,
+    style_lsc2_sr_ndvi,
+    style_lsc2_sr_ndwi,
+    style_lsc2_sr_mndwi,
+    style_lsc2_sr_pure_blue,
+    style_lsc2_sr_pure_green,
+    style_lsc2_sr_pure_red,
+    style_lsc2_sr_pure_nir,
+    style_lsc2_sr_pure_swir1,
+    style_lsc2_sr_pure_swir2,
+]
+
+#detangle common styles from satellite names!

--- a/services/ows_refactored/surface_reflectance/style_sr_cfg.py
+++ b/services/ows_refactored/surface_reflectance/style_sr_cfg.py
@@ -845,7 +845,7 @@ style_lsc2_sr_mndwi = {
     "title": "MNDWI - Green, SWIR",
     "abstract": "Modified Normalised Difference Water Index - a derived index that correlates "
     "well with the existence of water (Xu 2006)",
-    "index_expression": "((green-7273)-(swir-7273))/((green-7273)+(swir-7273))",
+    "index_expression": "((green-7273)-(swir_1-7273))/((green-7273)+(swir_1-7273))",
     "color_ramp": [
         {"value": -0.1, "color": "#f7fbff", "alpha": 0.0},
         {"value": 0.0, "color": "#d8e7f5"},
@@ -902,26 +902,26 @@ style_lsc2_sr_pure_nir = {
     "scale_range": [1.0, 19636.0],
 }
 
-style_lsc2_sr_pure_swir1 = {
-    "name": "swir1",
+style_lsc2_sr_swir_1 = {
+    "name": "swir_1",
     "title": "Shortwave Infrared 1 (SWIR1)",
     "abstract": "Shortwave infrared band 1",
     "components": {
-        "red": {"swir1": 1.0},
-        "green": {"swir1": 1.0},
-        "blue": {"swir1": 1.0},
+        "red": {"swir_1": 1.0},
+        "green": {"swir_1": 1.0},
+        "blue": {"swir_1": 1.0},
     },
     "scale_range": [1.0, 19636.0],
 }
 
-style_lsc2_sr_pure_swir2 = {
-    "name": "swir2",
+style_lsc2_sr_swir_2 = {
+    "name": "swir_2",
     "title": "Shortwave Infrared 2 (SWIR2)",
     "abstract": "Shortwave infrared band 2",
     "components": {
-        "red": {"swir2": 1.0},
-        "green": {"swir2": 1.0},
-        "blue": {"swir2": 1.0},
+        "red": {"swir_2": 1.0},
+        "green": {"swir_2": 1.0},
+        "blue": {"swir_2": 1.0},
     },
     "scale_range": [1.0, 19636.0],
 }
@@ -936,8 +936,8 @@ styles_lsc2_sr_list = [
     style_lsc2_sr_pure_green,
     style_lsc2_sr_pure_red,
     style_lsc2_sr_pure_nir,
-    style_lsc2_sr_pure_swir1,
-    style_lsc2_sr_pure_swir2,
+    style_lsc2_sr_swir_1,
+    style_lsc2_sr_swir_2,
 ]
 
 # detangle common styles from satellite names!

--- a/services/ows_refactored/surface_reflectance/style_sr_cfg.py
+++ b/services/ows_refactored/surface_reflectance/style_sr_cfg.py
@@ -882,7 +882,7 @@ style_lsc2_sr_pure_red = {
     "name": "red",
     "title": "Red",
     "abstract": "Red band",
-    "components":{
+    "components": {
         "red": {"red": 1.0},
         "green": {"red": 1.0},
         "blue": {"red": 1.0},

--- a/services/ows_refactored/surface_reflectance/style_sr_cfg.py
+++ b/services/ows_refactored/surface_reflectance/style_sr_cfg.py
@@ -664,10 +664,6 @@ style_tmad_rgb_std = {
         },
     },
     "additional_bands": ["sdev", "bcdev", "edev"],
-    "legend": {
-        "show_legend": True,
-        "url": "https://deafrica-services.s3.af-south-1.amazonaws.com/gm_s2_annual/gm_s2_annual_legend.png",
-    },
 }
 
 style_tmad_rgb_sens = {
@@ -691,10 +687,6 @@ style_tmad_rgb_sens = {
                 "scale_from": [0.008, 0.07],
             }
         },
-    },
-    "legend": {
-        "show_legend": True,
-        "url": "https://deafrica-services.s3.af-south-1.amazonaws.com/gm_s2_annual/gm_s2_annual_legend.png",
     },
 }
 
@@ -802,7 +794,7 @@ style_lsc2_sr_ndvi = {
     "name": "ndvi",
     "title": "NDVI - Red, NIR",
     "abstract": "Normalised Difference Vegetation Index - a derived index that correlates well with the existence of vegetation",
-    "index_expression": "((nir-55000)-(red-55000))/((nir-55000)+(red-55000))",
+    "index_expression": "((nir-7273)-(red-7273))/((nir-7273)+(red-7273))",
     "color_ramp": [
         {"value": -0.0, "color": "#8F3F20", "alpha": 0.0},
         {"value": 0.0, "color": "#8F3F20", "alpha": 1.0},
@@ -824,7 +816,7 @@ style_lsc2_sr_ndwi = {
     "name": "ndwi",
     "title": "NDWI - Green, NIR",
     "abstract": "Normalised Difference Water Index - a derived index that correlates well with the existence of water (McFeeters 1996)",
-    "index_expression": "((green-55000)-(nir-55000))/((green-55000)+(nir-55000))",
+    "index_expression": "((green-7273)-(nir-7273))/((green-7273)+(nir-7273))",
     "color_ramp": [
         {"value": -0.1, "color": "#f7fbff", "alpha": 0.0},
         {"value": 0.0, "color": "#d8e7f5", "legend": {"prefix": "<"}},
@@ -853,7 +845,7 @@ style_lsc2_sr_mndwi = {
     "title": "MNDWI - Green, SWIR",
     "abstract": "Modified Normalised Difference Water Index - a derived index that correlates "
     "well with the existence of water (Xu 2006)",
-    "index_expression": "((green-55000)-(swir-55000))/((green-55000)+(swir-55000))",
+    "index_expression": "((green-7273)-(swir-7273))/((green-7273)+(swir-7273))",
     "color_ramp": [
         {"value": -0.1, "color": "#f7fbff", "alpha": 0.0},
         {"value": 0.0, "color": "#d8e7f5"},

--- a/services/ows_refactored/surface_reflectance/style_sr_cfg.py
+++ b/services/ows_refactored/surface_reflectance/style_sr_cfg.py
@@ -794,12 +794,7 @@ style_lsc2_sr_ndvi = {
     "name": "ndvi",
     "title": "NDVI - Red, NIR",
     "abstract": "Normalised Difference Vegetation Index - a derived index that correlates well with the existence of vegetation",
-    "index_function": {
-        "function": "datacube_ows.band_utils.norm_diff",
-        "mapped_bands": True,
-        "kwargs": {"band1": "nir", "band2": "red"},
-    },
-    "needed_bands": ["red", "nir"],
+    "index_expression": "((nir-55000)-(red-55000))/((nir-55000)+(red-55000))",
     "color_ramp": [
         {"value": -0.0, "color": "#8F3F20", "alpha": 0.0},
         {"value": 0.0, "color": "#8F3F20", "alpha": 1.0},
@@ -821,12 +816,7 @@ style_lsc2_sr_ndwi = {
     "name": "ndwi",
     "title": "NDWI - Green, NIR",
     "abstract": "Normalised Difference Water Index - a derived index that correlates well with the existence of water (McFeeters 1996)",
-    "index_function": {
-        "function": "datacube_ows.band_utils.norm_diff",
-        "mapped_bands": True,
-        "kwargs": {"band1": "green", "band2": "nir"},
-    },
-    "needed_bands": ["green", "nir"],
+    "index_expression": "((green-55000)-(nir-55000))/((green-55000)+(nir-55000))",
     "color_ramp": [
         {"value": -0.1, "color": "#f7fbff", "alpha": 0.0},
         {"value": 0.0, "color": "#d8e7f5", "legend": {"prefix": "<"}},
@@ -855,12 +845,7 @@ style_lsc2_sr_mndwi = {
     "title": "MNDWI - Green, SWIR",
     "abstract": "Modified Normalised Difference Water Index - a derived index that correlates "
     "well with the existence of water (Xu 2006)",
-    "index_function": {
-        "function": "datacube_ows.band_utils.norm_diff",
-        "mapped_bands": True,
-        "kwargs": {"band1": "green", "band2": "swir1"},
-    },
-    "needed_bands": ["green", "swir1"],
+    "index_expression": "((green-55000)-(swir-55000))/((green-55000)+(swir-55000))",
     "color_ramp": [
         {"value": -0.1, "color": "#f7fbff", "alpha": 0.0},
         {"value": 0.0, "color": "#d8e7f5"},

--- a/services/ows_refactored/surface_reflectance/style_sr_cfg.py
+++ b/services/ows_refactored/surface_reflectance/style_sr_cfg.py
@@ -772,7 +772,7 @@ style_lsc2_sr_simple_rgb = {
     "abstract": "True-colour image, using the red, green and blue bands",
     "components": {
         "red": {"red": 1.0},
-        "green": {"green": 1.0}, 
+        "green": {"green": 1.0},
         "blue": {"blue": 1.0}
     },
     "scale_range": [1.0, 19636.0],
@@ -850,6 +850,29 @@ style_lsc2_sr_ndwi = {
     },
 }
 
+style_lsc2_sr_mndwi = {
+    "name": "mndwi",
+    "title": "MNDWI - Green, SWIR",
+    "abstract": "Modified Normalised Difference Water Index - a derived index that correlates "
+    "well with the existence of water (Xu 2006)",
+    "index_function": {
+        "function": "datacube_ows.band_utils.norm_diff",
+        "mapped_bands": True,
+        "kwargs": {"band1": "green", "band2": "swir1"},
+    },
+    "needed_bands": ["green", "swir1"],
+    "color_ramp": [
+        {"value": -0.1, "color": "#f7fbff", "alpha": 0.0},
+        {"value": 0.0, "color": "#d8e7f5"},
+        {"value": 0.2, "color": "#b0d2e8"},
+        {"value": 0.4, "color": "#73b3d8"},
+        {"value": 0.6, "color": "#3e8ec4"},
+        {"value": 0.8, "color": "#1563aa"},
+        {"value": 1.0, "color": "#08306b"},
+    ],
+    "legend": legend_idx_0_1_5ticks,
+}
+
 style_lsc2_sr_pure_blue = {
     "name": "blue",
     "title": "Blue",
@@ -874,7 +897,10 @@ style_lsc2_sr_pure_red = {
     "name": "red",
     "title": "Red",
     "abstract": "Red band",
-    "components": {"red": {"red": 1.0}, "green": {"red": 1.0}, "blue": {"red": 1.0}
+    "components":{
+        "red": {"red": 1.0},
+        "green": {"red": 1.0},
+        "blue": {"red": 1.0},
     },
     "scale_range": [1.0, 19636.0],
 }
@@ -883,7 +909,11 @@ style_lsc2_sr_pure_nir = {
     "name": "nir",
     "title": "Near Infrared (NIR)",
     "abstract": "Near infra-red band",
-    "components": {"red": {"nir": 1.0}, "green": {"nir": 1.0}, "blue": {"nir": 1.0}},
+    "components": {
+        "red": {"nir": 1.0},
+        "green": {"nir": 1.0},
+        "blue": {"nir": 1.0}
+    },
     "scale_range": [1.0, 19636.0],
 }
 
@@ -925,4 +955,4 @@ styles_lsc2_sr_list = [
     style_lsc2_sr_pure_swir2,
 ]
 
-#detangle common styles from satellite names!
+# detangle common styles from satellite names!


### PR DESCRIPTION
Changed files:
 * `style_sr_cfg.py`: 11 styles added for `lsc2_sr`, compiled in a new styles list `styles_lsc2_sr_list`. Scaling has been changed from 0-10000 to 1-65455 and existing ranges scaled accordingly
 * `band_sr_cfg.py`: Common Landsat bands added to a new band list `bands_lsc2_sr` *note it is the same as the `bands_ls` list but so far has been separated so the old Landsat configs can be reorganised on a different occasion*
 * `ows_sr_cfg.py`: "Collection 1" mentions upgraded to "Collection 2". "Five countries" replaced with "all Africa". Style and band list references updated to the new ones mentioned above

**To be added:** `ls_st` configs for surface temperature

Submitting the PR now for review. I expect some whitespace is causing issues but would like to check nothing else is. 