### PR TITLE
changes to lookup table for cirrus

### DIFF
--- a/dev/alchemist/wofs_ls.alchemist.yaml
+++ b/dev/alchemist/wofs_ls.alchemist.yaml
@@ -35,15 +35,18 @@ output:
   preview_image_singleband:
     measurement: water
     lookup_table:
-      0: [150, 150, 110] # dry
-      1: [0, 0, 0] # nodata
-      16: [119, 104, 87] # terrain
-      32: [89, 88, 86] # cloud_shadow
-      64: [216, 215, 214] # cloud
-      80: [242, 220, 180] # cloudy terrain
-      128: [79, 129, 189] # water
-      160: [51, 82, 119] # shady water
+      0: [150, 150, 110]   # dry
+      1: [0, 0, 0]         # nodata
+      16: [119, 104, 87]   # terrain
+      32: [89, 88, 86]     # cloud_shadow
+      64: [216, 215, 214]  # cloud
+      80: [242, 220, 180]  # cloudy terrain
+      96: [216, 215, 214]  # cloudy shadow
+      112: [242, 220, 180] # cloudy shady terrain
+      128: [79, 129, 189]  # water
+      160: [51, 82, 119]   # shady water
       192: [186, 211, 242] # cloudy water
+      224: [186, 211, 242] # cloudy shady water
   write_data_settings:
     overview_resampling: nearest
   reference_source_dataset: True


### PR DESCRIPTION
Additions to the lookup table for the colours of the quicklook when the cirrus is included.
 - needed because with cirrus, shadow and cloud can occur at the same location