### PR TITLE
Update native CRS and resolution entries.

### DIFF
--- a/services/ows_refactored/agriculture/ows_crop_mask_cfg.py
+++ b/services/ows_refactored/agriculture/ows_crop_mask_cfg.py
@@ -210,10 +210,12 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
         "always_fetch_bands": [],
         "manual_merge": False,
     },
+    "native_crs": "epsg:6933",
+    "native_resolution": [10, -10],
     "wcs": {
+        "default_bands": ["mask", "prob"],
         "native_crs": "epsg:6933",
         "native_resolution": [10, -10],
-        "default_bands": ["mask", "prob"],
     },
     "styling": {
         "default_style": "green",

--- a/services/ows_refactored/elevation/ows_srtm_cfg.py
+++ b/services/ows_refactored/elevation/ows_srtm_cfg.py
@@ -95,13 +95,18 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
         "always_fetch_bands": [],
         "manual_merge": False,
     },
+    "native_crs": "EPSG:4326",
+    "native_resolution": [
+        0.000277777777780,
+        -0.000277777777780,
+    ],
     "wcs": {
+        "default_bands": ["elevation"],
         "native_crs": "EPSG:4326",
         "native_resolution": [
             0.000277777777780,
             -0.000277777777780,
         ],
-        "default_bands": ["elevation"],
     },
     "styling": {
         "default_style": "greyscale",

--- a/services/ows_refactored/elevation/ows_us_srtm_cfg.py
+++ b/services/ows_refactored/elevation/ows_us_srtm_cfg.py
@@ -95,13 +95,18 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
         "always_fetch_bands": [],
         "manual_merge": False,
     },
+    "native_crs": "EPSG:4326",
+    "native_resolution": [
+        0.000277777777780,
+        -0.000277777777780,
+    ],
     "wcs": {
+        "default_bands": ["elevation"],
         "native_crs": "EPSG:4326",
         "native_resolution": [
             0.000277777777780,
             -0.000277777777780,
         ],
-        "default_bands": ["elevation"],
     },
     "styling": {
         "default_style": "greyscale",

--- a/services/ows_refactored/pixel_count/ows_pc_ls_annual_cfg.py
+++ b/services/ows_refactored/pixel_count/ows_pc_ls_annual_cfg.py
@@ -190,7 +190,7 @@ Annual number of observations and number of clear observations. This product is 
     "bands": bands_pc_ls8_annual,
     "resource_limits": reslim_srtm,
     "native_crs": "EPSG:6933",
-    "native_resolution": [30.0, -30,0],
+    "native_resolution": [30.0, -30.0],
     "image_processing": {
         "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
         "always_fetch_bands": [],

--- a/services/ows_refactored/pixel_count/ows_pc_ls_annual_cfg.py
+++ b/services/ows_refactored/pixel_count/ows_pc_ls_annual_cfg.py
@@ -189,6 +189,8 @@ Annual number of observations and number of clear observations. This product is 
     "time_resolution": "year",
     "bands": bands_pc_ls8_annual,
     "resource_limits": reslim_srtm,
+    "native_crs": "EPSG:6933",
+    "native_resolution": [30.0, -30,0],
     "image_processing": {
         "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
         "always_fetch_bands": [],

--- a/services/ows_refactored/pixel_count/ows_pc_s2_annual_cfg.py
+++ b/services/ows_refactored/pixel_count/ows_pc_s2_annual_cfg.py
@@ -118,6 +118,8 @@ Annual number of observations and number of clear observations. This product is 
     "time_resolution": "year",
     "bands": bands_pc_s2_annual,
     "resource_limits": reslim_srtm,
+    "native_crs": "EPSG:6933",
+    "native_resolution": [10.0, -10,0],
     "image_processing": {
         "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
         "always_fetch_bands": [],

--- a/services/ows_refactored/pixel_count/ows_pc_s2_annual_cfg.py
+++ b/services/ows_refactored/pixel_count/ows_pc_s2_annual_cfg.py
@@ -119,7 +119,7 @@ Annual number of observations and number of clear observations. This product is 
     "bands": bands_pc_s2_annual,
     "resource_limits": reslim_srtm,
     "native_crs": "EPSG:6933",
-    "native_resolution": [10.0, -10,0],
+    "native_resolution": [10.0, -10.0],
     "image_processing": {
         "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
         "always_fetch_bands": [],

--- a/services/ows_refactored/radar_backscatter/ows_alos_cfg.py
+++ b/services/ows_refactored/radar_backscatter/ows_alos_cfg.py
@@ -150,6 +150,8 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
             "ignore_info_flags": [],
         },
     ],
+    "native_crs": "EPSG:4326",
+    "native_resolution": [0.000222222222222, -0.000222222222222],
     "wcs": {
         "native_crs": "EPSG:4326",
         "native_resolution": [0.000222222222222, -0.000222222222222],

--- a/services/ows_refactored/radar_backscatter/ows_jers_cfg.py
+++ b/services/ows_refactored/radar_backscatter/ows_jers_cfg.py
@@ -69,6 +69,11 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
             "ignore_info_flags": [],
         },
     ],
+    "native_crs": "EPSG:4326",
+    "native_resolution": [
+        0.000222222222222,
+        -0.000222222222222,
+    ],
     "wcs": {
         "native_crs": "EPSG:4326",
         "native_resolution": [

--- a/services/ows_refactored/radar_backscatter/ows_sentinel1_cfg.py
+++ b/services/ows_refactored/radar_backscatter/ows_sentinel1_cfg.py
@@ -116,6 +116,8 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
             "band": "mask",
         },
     ],
+    "native_crs": "EPSG:4326",
+    "native_resolution": [0.0002, -0.0002],
     "wcs": {
         "native_crs": "EPSG:4326",
         "native_resolution": [0.0002, -0.0002],

--- a/services/ows_refactored/radar_backscatter/ows_us_jers_cfg.py
+++ b/services/ows_refactored/radar_backscatter/ows_us_jers_cfg.py
@@ -67,6 +67,11 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
         "band": "mask",
         "ignore_info_flags": [],
     },
+    "native_crs": "EPSG:4326",
+    "native_resolution": [
+        0.000222222222222,
+        -0.000222222222222,
+    ],
     "wcs": {
         "native_crs": "EPSG:4326",
         "native_resolution": [

--- a/services/ows_refactored/surface_reflectance/ows_geomedian_cfg.py
+++ b/services/ows_refactored/surface_reflectance/ows_geomedian_cfg.py
@@ -35,6 +35,8 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
                 "always_fetch_bands": [],
                 "manual_merge": False,
             },
+            "native_crs": "EPSG:6933",
+            "native_resolution": [30.0, -30.0],
             "wcs": {
                 "native_crs": "EPSG:6933",
                 "native_resolution": [30.0, -30.0],
@@ -82,6 +84,8 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
                 "manual_merge": False,  # True
                 "apply_solar_corrections": False,
             },
+            "native_crs": "EPSG:6933",
+            "native_resolution": [10.0, -10.0],
             "wcs": {
                 "native_crs": "EPSG:6933",
                 "native_resolution": [10.0, -10.0],

--- a/services/ows_refactored/surface_reflectance/ows_gm_s2_annual_cfg.py
+++ b/services/ows_refactored/surface_reflectance/ows_gm_s2_annual_cfg.py
@@ -45,6 +45,8 @@ For more information on the algorithm, see https://doi.org/10.1109/TGRS.2017.272
         "manual_merge": False,  # True
         "apply_solar_corrections": False,
     },
+    "native_crs": "EPSG:6933",
+    "native_resolution": [10.0, -10.0],
     "wcs": {
         "native_crs": "EPSG:6933",
         "native_resolution": [10.0, -10.0],

--- a/services/ows_refactored/surface_reflectance/ows_gm_s2_semiannual_cfg.py
+++ b/services/ows_refactored/surface_reflectance/ows_gm_s2_semiannual_cfg.py
@@ -45,6 +45,8 @@ For more information on the algorithm, see https://doi.org/10.1109/TGRS.2017.272
         "manual_merge": False,  # True
         "apply_solar_corrections": False,
     },
+    "native_crs": "EPSG:6933",
+    "native_resolution": [10.0, -10.0],
     "wcs": {
         "native_crs": "EPSG:6933",
         "native_resolution": [10.0, -10.0],

--- a/services/ows_refactored/surface_reflectance/ows_lsc2_sr_cfg.py
+++ b/services/ows_refactored/surface_reflectance/ows_lsc2_sr_cfg.py
@@ -33,8 +33,10 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
         "manual_merge": False,  # True
         "apply_solar_corrections": False,
     },
+    "native_crs": "EPSG:3857",
+    "native_resolution": [30.0, -30.0],
     "wcs": {
-        "native_crs": "EPSG:4326",
+        "native_crs": "EPSG:3857",
         "native_resolution": [30.0, -30.0],
         "default_bands": ["red", "green", "blue"],
     },
@@ -72,8 +74,10 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
         "manual_merge": False,  # True
         "apply_solar_corrections": False,
     },
+    "native_crs": "EPSG:3857",
+    "native_resolution": [30.0, -30.0],
     "wcs": {
-        "native_crs": "EPSG:4326",
+        "native_crs": "EPSG:3857",
         "native_resolution": [30.0, -30.0],
         "default_bands": ["red", "green", "blue"],
     },
@@ -111,8 +115,10 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
         "manual_merge": False,  # True
         "apply_solar_corrections": False,
     },
+    "native_crs": "EPSG:3857",
+    "native_resolution": [30.0, -30.0],
     "wcs": {
-        "native_crs": "EPSG:4326",
+        "native_crs": "EPSG:3857",
         "native_resolution": [30.0, -30.0],
         "default_bands": ["red", "green", "blue"],
     },

--- a/services/ows_refactored/surface_reflectance/ows_s2_cfg.py
+++ b/services/ows_refactored/surface_reflectance/ows_s2_cfg.py
@@ -28,8 +28,10 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
         "manual_merge": False,  # True
         "apply_solar_corrections": False,
     },
+    "native_crs": "EPSG:3857",
+    "native_resolution": [30.0, -30.0],
     "wcs": {
-        "native_crs": "EPSG:4326",
+        "native_crs": "EPSG:3857",
         "native_resolution": [30.0, -30.0],
         "default_bands": ["red", "green", "blue"],
     },

--- a/services/ows_refactored/surface_reflectance/ows_sr_cfg.py
+++ b/services/ows_refactored/surface_reflectance/ows_sr_cfg.py
@@ -36,8 +36,10 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
                 "manual_merge": False,  # True
                 "apply_solar_corrections": False,
             },
+            "native_crs": "EPSG:3857",
+            "native_resolution": [30.0, -30.0],
             "wcs": {
-                "native_crs": "EPSG:4326",
+                "native_crs": "EPSG:3857",
                 "native_resolution": [30.0, -30.0],
                 "default_bands": ["red", "green", "blue"],
             },
@@ -71,8 +73,10 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
                 "manual_merge": False,  # True
                 "apply_solar_corrections": False,
             },
+            "native_crs": "EPSG:3857",
+            "native_resolution": [30.0, -30.0],
             "wcs": {
-                "native_crs": "EPSG:4326",
+                "native_crs": "EPSG:3857",
                 "native_resolution": [30.0, -30.0],
                 "default_bands": ["red", "green", "blue"],
             },
@@ -106,8 +110,10 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
                 "manual_merge": False,  # True
                 "apply_solar_corrections": False,
             },
+            "native_crs": "EPSG:3857",
+            "native_resolution": [30.0, -30.0],
             "wcs": {
-                "native_crs": "EPSG:4326",
+                "native_crs": "EPSG:3857",
                 "native_resolution": [30.0, -30.0],
                 "default_bands": ["red", "green", "blue"],
             },

--- a/services/ows_refactored/surface_temperature/ows_lsc2_st_cfg.py
+++ b/services/ows_refactored/surface_temperature/ows_lsc2_st_cfg.py
@@ -161,6 +161,8 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
             "band": "QA_PIXEL",
         },
     ],
+    "native_crs": "EPSG:3857",
+    "native_resolution": [30.0, -30.0],
     "wcs": {
         "native_crs": "EPSG:4326",
         "native_resolution": [30.0, -30.0],
@@ -210,8 +212,10 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
             "band": "QA_PIXEL",
         },
     ],
+    "native_crs": "EPSG:3857",
+    "native_resolution": [30.0, -30.0],
     "wcs": {
-        "native_crs": "EPSG:4326",
+        "native_crs": "EPSG:3857",
         "native_resolution": [30.0, -30.0],
         "default_bands": ["st", "st_qa", "pq"],
     },
@@ -258,8 +262,10 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
             "band": "QA_PIXEL",
         },
     ],
+    "native_crs": "EPSG:3857",
+    "native_resolution": [30.0, -30.0],
     "wcs": {
-        "native_crs": "EPSG:4326",
+        "native_crs": "EPSG:3857",
         "native_resolution": [30.0, -30.0],
         "default_bands": ["st", "st_qa", "pq"],
     },

--- a/services/ows_refactored/vegetation/ows_fc_cfg.py
+++ b/services/ows_refactored/vegetation/ows_fc_cfg.py
@@ -94,8 +94,10 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
             "ignore_info_flags": [],
         },
     ],
+    "native_crs": "EPSG:3857",
+    "native_resolution": [30.0, -30.0],
     "wcs": {
-        "native_crs": "EPSG:4326",
+        "native_crs": "EPSG:3857",
         "native_resolution": [30.0, -30.0],
         "default_bands": ["BS", "PV", "NPV"],
     },

--- a/services/ows_refactored/vegetation/ows_us_fc_cfg.py
+++ b/services/ows_refactored/vegetation/ows_us_fc_cfg.py
@@ -78,8 +78,10 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
         "fuse_func": "datacube_ows.wms_utils.wofls_fuser",
         "ignore_info_flags": [],
     },
+    "native_crs": "EPSG:3857",
+    "native_resolution": [30.0, -30.0],
     "wcs": {
-        "native_crs": "EPSG:4326",
+        "native_crs": "EPSG:3857",
         "native_resolution": [30.0, -30.0],
         "default_bands": ["BS", "PV", "NPV"],
     },

--- a/services/ows_refactored/wofs/ows_wofs_cfg.py
+++ b/services/ows_refactored/wofs/ows_wofs_cfg.py
@@ -36,8 +36,10 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
                 "always_fetch_bands": [],
                 "manual_merge": False,
             },
+            "native_crs": "EPSG:3857",
+            "native_resolution": [30.0, -30.0],
             "wcs": {
-                "native_crs": "EPSG:4326",
+                "native_crs": "EPSG:3857",
                 "native_resolution": [30.0, -30.0],
                 "default_bands": ["water"],
             },
@@ -76,6 +78,8 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
                 "always_fetch_bands": [],
                 "manual_merge": False,
             },
+            "native_crs": "ESRI:102022",
+            "native_resolution": [30.0, -30.0],
             "wcs": {
                 "native_crs": "ESRI:102022",
                 "native_resolution": [30.0, -30.0],

--- a/services/ows_refactored/wofs/ows_wofs_ls_alltime_cfg.py
+++ b/services/ows_refactored/wofs/ows_wofs_ls_alltime_cfg.py
@@ -192,6 +192,8 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
         "always_fetch_bands": [],
         "manual_merge": False,
     },
+    "native_crs": "EPSG:6933",
+    "native_resolution": [30.0, -30.0],
     "wcs": {
         "native_crs": "EPSG:6933",
         "native_resolution": [30.0, -30.0],

--- a/services/ows_refactored/wofs/ows_wofs_ls_annual_cfg.py
+++ b/services/ows_refactored/wofs/ows_wofs_ls_annual_cfg.py
@@ -188,6 +188,8 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
         "always_fetch_bands": [],
         "manual_merge": False,
     },
+    "native_crs": "EPSG:6933",
+    "native_resolution": [30.0, -30.0],
     "wcs": {
         "native_crs": "EPSG:6933",
         "native_resolution": [30.0, -30.0],

--- a/services/ows_refactored/wofs/ows_wofs_ls_cfg.py
+++ b/services/ows_refactored/wofs/ows_wofs_ls_cfg.py
@@ -184,8 +184,10 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
             "fuse_func": "datacube_ows.wms_utils.wofls_fuser",
         },
     ],
+    "native_crs": "EPSG:3857",
+    "native_resolution": [30.0, -30.0],
     "wcs": {
-        "native_crs": "EPSG:4326",
+        "native_crs": "EPSG:3857",
         "native_resolution": [30.0, -30.0],
         "default_bands": ["water"],
     },

--- a/services/ows_refactored/wofs/ows_wofsc2_cfg.py
+++ b/services/ows_refactored/wofs/ows_wofsc2_cfg.py
@@ -38,8 +38,10 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
                 "always_fetch_bands": [],
                 "manual_merge": False,
             },
+            "native_crs": "EPSG:3857",
+            "native_resolution": [30.0, -30.0],
             "wcs": {
-                "native_crs": "EPSG:4326",
+                "native_crs": "EPSG:3857",
                 "native_resolution": [30.0, -30.0],
                 "default_bands": ["water"],
             },
@@ -78,6 +80,8 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
                 "always_fetch_bands": [],
                 "manual_merge": False,
             },
+            "native_crs": "EPSG:6933",
+            "native_resolution": [30.0, -30.0],
             "wcs": {
                 "native_crs": "EPSG:6933",
                 "native_resolution": [30.0, -30.0],
@@ -114,6 +118,8 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
                 "always_fetch_bands": [],
                 "manual_merge": False,
             },
+            "native_crs": "EPSG:6933",
+            "native_resolution": [30.0, -30.0],
             "wcs": {
                 "native_crs": "EPSG:6933",
                 "native_resolution": [30.0, -30.0],
@@ -149,6 +155,8 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
                 "always_fetch_bands": [],
                 "manual_merge": False,
             },
+            "native_crs": "EPSG:6933",
+            "native_resolution": [30.0, -30.0],
             "wcs": {
                 "native_crs": "EPSG:6933",
                 "native_resolution": [30.0, -30.0],
@@ -188,6 +196,8 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
                 "always_fetch_bands": [],
                 "manual_merge": False,
             },
+            "native_crs": "EPSG:6933",
+            "native_resolution": [30.0, -30.0],
             "wcs": {
                 "native_crs": "EPSG:6933",
                 "native_resolution": [30.0, -30.0],
@@ -224,6 +234,8 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
                 "always_fetch_bands": [],
                 "manual_merge": False,
             },
+            "native_crs": "EPSG:6933",
+            "native_resolution": [30.0, -30.0],
             "wcs": {
                 "native_crs": "EPSG:6933",
                 "native_resolution": [30.0, -30.0],
@@ -259,6 +271,8 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
                 "always_fetch_bands": [],
                 "manual_merge": False,
             },
+            "native_crs": "EPSG:6933",
+            "native_resolution": [30.0, -30.0],
             "wcs": {
                 "native_crs": "EPSG:6933",
                 "native_resolution": [30.0, -30.0],


### PR DESCRIPTION
For #248 

I have left the native CRS and resolution configured in the old and new places so we don't accidentally break production.

I had to change the native_crs from EPSG:4326 to EPSG:3857 for a bunch of layers.  If you specify EPSG:4326 then the native_resolution is expressed in degrees (not metres) and (30, -30) doesn't mean what it is supposed to mean.