### PR TITLE
Remove redundant old-style native crs/resolution config.

### DIFF
--- a/services/ows_refactored/agriculture/ows_crop_mask_cfg.py
+++ b/services/ows_refactored/agriculture/ows_crop_mask_cfg.py
@@ -214,8 +214,6 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
     "native_resolution": [10, -10],
     "wcs": {
         "default_bands": ["mask", "prob"],
-        "native_crs": "epsg:6933",
-        "native_resolution": [10, -10],
     },
     "styling": {
         "default_style": "green",

--- a/services/ows_refactored/elevation/ows_srtm_cfg.py
+++ b/services/ows_refactored/elevation/ows_srtm_cfg.py
@@ -102,11 +102,6 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
     ],
     "wcs": {
         "default_bands": ["elevation"],
-        "native_crs": "EPSG:4326",
-        "native_resolution": [
-            0.000277777777780,
-            -0.000277777777780,
-        ],
     },
     "styling": {
         "default_style": "greyscale",

--- a/services/ows_refactored/elevation/ows_us_srtm_cfg.py
+++ b/services/ows_refactored/elevation/ows_us_srtm_cfg.py
@@ -102,11 +102,6 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
     ],
     "wcs": {
         "default_bands": ["elevation"],
-        "native_crs": "EPSG:4326",
-        "native_resolution": [
-            0.000277777777780,
-            -0.000277777777780,
-        ],
     },
     "styling": {
         "default_style": "greyscale",

--- a/services/ows_refactored/radar_backscatter/ows_alos_cfg.py
+++ b/services/ows_refactored/radar_backscatter/ows_alos_cfg.py
@@ -153,8 +153,6 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
     "native_crs": "EPSG:4326",
     "native_resolution": [0.000222222222222, -0.000222222222222],
     "wcs": {
-        "native_crs": "EPSG:4326",
-        "native_resolution": [0.000222222222222, -0.000222222222222],
         "default_bands": ["hh", "hv", "mask"],
     },
     "styling": {

--- a/services/ows_refactored/radar_backscatter/ows_jers_cfg.py
+++ b/services/ows_refactored/radar_backscatter/ows_jers_cfg.py
@@ -75,11 +75,6 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
         -0.000222222222222,
     ],
     "wcs": {
-        "native_crs": "EPSG:4326",
-        "native_resolution": [
-            0.000222222222222,
-            -0.000222222222222,
-        ],
         "default_bands": ["hh", "mask"],
     },
     "styling": {

--- a/services/ows_refactored/radar_backscatter/ows_sentinel1_cfg.py
+++ b/services/ows_refactored/radar_backscatter/ows_sentinel1_cfg.py
@@ -119,8 +119,6 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
     "native_crs": "EPSG:4326",
     "native_resolution": [0.0002, -0.0002],
     "wcs": {
-        "native_crs": "EPSG:4326",
-        "native_resolution": [0.0002, -0.0002],
         "default_bands": ["vv", "vh", "angle", "area", "mask"],
     },
     "styling": {

--- a/services/ows_refactored/radar_backscatter/ows_us_jers_cfg.py
+++ b/services/ows_refactored/radar_backscatter/ows_us_jers_cfg.py
@@ -73,11 +73,6 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
         -0.000222222222222,
     ],
     "wcs": {
-        "native_crs": "EPSG:4326",
-        "native_resolution": [
-            0.000222222222222,
-            -0.000222222222222,
-        ],
         "default_bands": ["hh", "mask"],
     },
     "styling": {

--- a/services/ows_refactored/surface_reflectance/ows_geomedian_cfg.py
+++ b/services/ows_refactored/surface_reflectance/ows_geomedian_cfg.py
@@ -38,8 +38,6 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
             "native_crs": "EPSG:6933",
             "native_resolution": [30.0, -30.0],
             "wcs": {
-                "native_crs": "EPSG:6933",
-                "native_resolution": [30.0, -30.0],
                 "default_bands": ["red", "green", "blue"],
             },
             "styling": {
@@ -87,8 +85,6 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
             "native_crs": "EPSG:6933",
             "native_resolution": [10.0, -10.0],
             "wcs": {
-                "native_crs": "EPSG:6933",
-                "native_resolution": [10.0, -10.0],
                 "default_bands": ["red", "green", "blue"],
             },
             "styling": {

--- a/services/ows_refactored/surface_reflectance/ows_gm_s2_annual_cfg.py
+++ b/services/ows_refactored/surface_reflectance/ows_gm_s2_annual_cfg.py
@@ -48,8 +48,6 @@ For more information on the algorithm, see https://doi.org/10.1109/TGRS.2017.272
     "native_crs": "EPSG:6933",
     "native_resolution": [10.0, -10.0],
     "wcs": {
-        "native_crs": "EPSG:6933",
-        "native_resolution": [10.0, -10.0],
         "default_bands": ["red", "green", "blue"],
     },
     "styling": {

--- a/services/ows_refactored/surface_reflectance/ows_gm_s2_semiannual_cfg.py
+++ b/services/ows_refactored/surface_reflectance/ows_gm_s2_semiannual_cfg.py
@@ -48,8 +48,6 @@ For more information on the algorithm, see https://doi.org/10.1109/TGRS.2017.272
     "native_crs": "EPSG:6933",
     "native_resolution": [10.0, -10.0],
     "wcs": {
-        "native_crs": "EPSG:6933",
-        "native_resolution": [10.0, -10.0],
         "default_bands": ["red", "green", "blue"],
     },
     "styling": {

--- a/services/ows_refactored/surface_reflectance/ows_lsc2_sr_cfg.py
+++ b/services/ows_refactored/surface_reflectance/ows_lsc2_sr_cfg.py
@@ -36,8 +36,6 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
     "native_crs": "EPSG:3857",
     "native_resolution": [30.0, -30.0],
     "wcs": {
-        "native_crs": "EPSG:3857",
-        "native_resolution": [30.0, -30.0],
         "default_bands": ["red", "green", "blue"],
     },
     "styling": {
@@ -77,8 +75,6 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
     "native_crs": "EPSG:3857",
     "native_resolution": [30.0, -30.0],
     "wcs": {
-        "native_crs": "EPSG:3857",
-        "native_resolution": [30.0, -30.0],
         "default_bands": ["red", "green", "blue"],
     },
     "styling": {
@@ -118,8 +114,6 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
     "native_crs": "EPSG:3857",
     "native_resolution": [30.0, -30.0],
     "wcs": {
-        "native_crs": "EPSG:3857",
-        "native_resolution": [30.0, -30.0],
         "default_bands": ["red", "green", "blue"],
     },
     "styling": {

--- a/services/ows_refactored/surface_reflectance/ows_s2_cfg.py
+++ b/services/ows_refactored/surface_reflectance/ows_s2_cfg.py
@@ -31,8 +31,6 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
     "native_crs": "EPSG:3857",
     "native_resolution": [30.0, -30.0],
     "wcs": {
-        "native_crs": "EPSG:3857",
-        "native_resolution": [30.0, -30.0],
         "default_bands": ["red", "green", "blue"],
     },
     "styling": {

--- a/services/ows_refactored/surface_reflectance/ows_sr_cfg.py
+++ b/services/ows_refactored/surface_reflectance/ows_sr_cfg.py
@@ -39,8 +39,6 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
             "native_crs": "EPSG:3857",
             "native_resolution": [30.0, -30.0],
             "wcs": {
-                "native_crs": "EPSG:3857",
-                "native_resolution": [30.0, -30.0],
                 "default_bands": ["red", "green", "blue"],
             },
             "styling": {
@@ -76,8 +74,6 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
             "native_crs": "EPSG:3857",
             "native_resolution": [30.0, -30.0],
             "wcs": {
-                "native_crs": "EPSG:3857",
-                "native_resolution": [30.0, -30.0],
                 "default_bands": ["red", "green", "blue"],
             },
             "styling": {
@@ -113,8 +109,6 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
             "native_crs": "EPSG:3857",
             "native_resolution": [30.0, -30.0],
             "wcs": {
-                "native_crs": "EPSG:3857",
-                "native_resolution": [30.0, -30.0],
                 "default_bands": ["red", "green", "blue"],
             },
             "styling": {

--- a/services/ows_refactored/surface_temperature/ows_lsc2_st_cfg.py
+++ b/services/ows_refactored/surface_temperature/ows_lsc2_st_cfg.py
@@ -164,8 +164,6 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
     "native_crs": "EPSG:3857",
     "native_resolution": [30.0, -30.0],
     "wcs": {
-        "native_crs": "EPSG:4326",
-        "native_resolution": [30.0, -30.0],
         "default_bands": ["st", "st_qa", "pq"],
     },
     "styling": {
@@ -215,8 +213,6 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
     "native_crs": "EPSG:3857",
     "native_resolution": [30.0, -30.0],
     "wcs": {
-        "native_crs": "EPSG:3857",
-        "native_resolution": [30.0, -30.0],
         "default_bands": ["st", "st_qa", "pq"],
     },
     "styling": {
@@ -265,8 +261,6 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
     "native_crs": "EPSG:3857",
     "native_resolution": [30.0, -30.0],
     "wcs": {
-        "native_crs": "EPSG:3857",
-        "native_resolution": [30.0, -30.0],
         "default_bands": ["st", "st_qa", "pq"],
     },
     "styling": {

--- a/services/ows_refactored/vegetation/ows_fc_cfg.py
+++ b/services/ows_refactored/vegetation/ows_fc_cfg.py
@@ -97,8 +97,6 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
     "native_crs": "EPSG:3857",
     "native_resolution": [30.0, -30.0],
     "wcs": {
-        "native_crs": "EPSG:3857",
-        "native_resolution": [30.0, -30.0],
         "default_bands": ["BS", "PV", "NPV"],
     },
     "styling": {

--- a/services/ows_refactored/vegetation/ows_us_fc_cfg.py
+++ b/services/ows_refactored/vegetation/ows_us_fc_cfg.py
@@ -81,8 +81,6 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
     "native_crs": "EPSG:3857",
     "native_resolution": [30.0, -30.0],
     "wcs": {
-        "native_crs": "EPSG:3857",
-        "native_resolution": [30.0, -30.0],
         "default_bands": ["BS", "PV", "NPV"],
     },
     "styling": {

--- a/services/ows_refactored/wofs/ows_wofs_cfg.py
+++ b/services/ows_refactored/wofs/ows_wofs_cfg.py
@@ -39,8 +39,6 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
             "native_crs": "EPSG:3857",
             "native_resolution": [30.0, -30.0],
             "wcs": {
-                "native_crs": "EPSG:3857",
-                "native_resolution": [30.0, -30.0],
                 "default_bands": ["water"],
             },
             "styling": {
@@ -81,8 +79,6 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
             "native_crs": "ESRI:102022",
             "native_resolution": [30.0, -30.0],
             "wcs": {
-                "native_crs": "ESRI:102022",
-                "native_resolution": [30.0, -30.0],
                 "default_bands": ["frequency"],
             },
             "styling": {

--- a/services/ows_refactored/wofs/ows_wofs_ls_alltime_cfg.py
+++ b/services/ows_refactored/wofs/ows_wofs_ls_alltime_cfg.py
@@ -195,8 +195,6 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
     "native_crs": "EPSG:6933",
     "native_resolution": [30.0, -30.0],
     "wcs": {
-        "native_crs": "EPSG:6933",
-        "native_resolution": [30.0, -30.0],
         "default_bands": ["frequency"],
     },
     "styling": {

--- a/services/ows_refactored/wofs/ows_wofs_ls_annual_cfg.py
+++ b/services/ows_refactored/wofs/ows_wofs_ls_annual_cfg.py
@@ -191,8 +191,6 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
     "native_crs": "EPSG:6933",
     "native_resolution": [30.0, -30.0],
     "wcs": {
-        "native_crs": "EPSG:6933",
-        "native_resolution": [30.0, -30.0],
         "default_bands": ["frequency", "count_wet", "count_clear"],
     },
     "styling": {

--- a/services/ows_refactored/wofs/ows_wofs_ls_cfg.py
+++ b/services/ows_refactored/wofs/ows_wofs_ls_cfg.py
@@ -187,8 +187,6 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
     "native_crs": "EPSG:3857",
     "native_resolution": [30.0, -30.0],
     "wcs": {
-        "native_crs": "EPSG:3857",
-        "native_resolution": [30.0, -30.0],
         "default_bands": ["water"],
     },
     "styling": {

--- a/services/ows_refactored/wofs/ows_wofsc2_cfg.py
+++ b/services/ows_refactored/wofs/ows_wofsc2_cfg.py
@@ -41,8 +41,6 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
             "native_crs": "EPSG:3857",
             "native_resolution": [30.0, -30.0],
             "wcs": {
-                "native_crs": "EPSG:3857",
-                "native_resolution": [30.0, -30.0],
                 "default_bands": ["water"],
             },
             "styling": {
@@ -83,8 +81,6 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
             "native_crs": "EPSG:6933",
             "native_resolution": [30.0, -30.0],
             "wcs": {
-                "native_crs": "EPSG:6933",
-                "native_resolution": [30.0, -30.0],
                 "default_bands": ["frequency"],
             },
             "styling": {
@@ -121,8 +117,6 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
             "native_crs": "EPSG:6933",
             "native_resolution": [30.0, -30.0],
             "wcs": {
-                "native_crs": "EPSG:6933",
-                "native_resolution": [30.0, -30.0],
                 "default_bands": ["count_wet"],
             },
             "styling": {
@@ -158,8 +152,6 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
             "native_crs": "EPSG:6933",
             "native_resolution": [30.0, -30.0],
             "wcs": {
-                "native_crs": "EPSG:6933",
-                "native_resolution": [30.0, -30.0],
                 "default_bands": ["count_clear"],
             },
             "styling": {
@@ -199,8 +191,6 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
             "native_crs": "EPSG:6933",
             "native_resolution": [30.0, -30.0],
             "wcs": {
-                "native_crs": "EPSG:6933",
-                "native_resolution": [30.0, -30.0],
                 "default_bands": ["frequency"],
             },
             "styling": {
@@ -237,8 +227,6 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
             "native_crs": "EPSG:6933",
             "native_resolution": [30.0, -30.0],
             "wcs": {
-                "native_crs": "EPSG:6933",
-                "native_resolution": [30.0, -30.0],
                 "default_bands": ["count_wet"],
             },
             "styling": {
@@ -274,8 +262,6 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
             "native_crs": "EPSG:6933",
             "native_resolution": [30.0, -30.0],
             "wcs": {
-                "native_crs": "EPSG:6933",
-                "native_resolution": [30.0, -30.0],
                 "default_bands": ["count_clear"],
             },
             "styling": {


### PR DESCRIPTION
Needed a cross-compatible config during transitional period for new native_crs/resolution configuration.

With the release of 1.8.16, we can cleanup the redundant config.