### PR TITLE
Retest deploying smart reslim to prod.

### DIFF
--- a/services/ows_refactored/prod_af_ows_root_cfg.py
+++ b/services/ows_refactored/prod_af_ows_root_cfg.py
@@ -145,7 +145,7 @@ ows_cfg = {
                                     "abstract": """Annual surface reflectance""",
                                     "layers": [
                                         {
-                                            "include": "ows_refactored.surface_reflectance.ows_gm_s2_annual_cfg.layer",
+                                            "include": "ows_refactored.surface_reflectance.ows_gm_s2_annual_cfg.dev_layer",
                                             "type": "python",
                                         },
                                     ],


### PR DESCRIPTION
The `dev_layer` for S-2 GeoMAD works well in the ows.dev deployment.
PR to use this same dev_layer in production environment.
Can be tested at `ows-latest` before any tagged versions are released.