### PR TITLE
Semiannuals - reduced min zoom

### DIFF
--- a/services/ows_refactored/common/ows_reslim_cfg.py
+++ b/services/ows_refactored/common/ows_reslim_cfg.py
@@ -1,9 +1,9 @@
 # reslim
 
-reslim_smart6 = {
+reslim_smart5 = {
     "wms": {
         "zoomed_out_fill_colour": [150, 180, 200, 160],
-        "min_zoom_level": 6.6,
+        "min_zoom_level": 5.6,
         # "max_datasets": 16, # Defaults to no dataset limit
     },
     "wcs": {

--- a/services/ows_refactored/surface_reflectance/ows_gm_s2_semiannual_cfg.py
+++ b/services/ows_refactored/surface_reflectance/ows_gm_s2_semiannual_cfg.py
@@ -1,4 +1,4 @@
-from ows_refactored.common.ows_reslim_cfg import reslim_zoom9, reslim_smart6
+from ows_refactored.common.ows_reslim_cfg import reslim_zoom9, reslim_smart5
 from ows_refactored.surface_reflectance.band_sr_cfg import bands_s2_gm
 from ows_refactored.surface_reflectance.style_sr_cfg import styles_gm_list
 
@@ -91,7 +91,7 @@ For more information on the algorithm, see https://doi.org/10.1109/TGRS.2017.272
     # "low_res_product_name": "gm_s2_annual_lowres",
     "bands": bands_s2_gm,
     "dynamic": False,
-    "resource_limits": reslim_smart6,
+    "resource_limits": reslim_smart5,
     "time_resolution": "month",
     "image_processing": {
         "extent_mask_func": "ows_refactored.common.ows_util_tools.mask_by_emad_nan",


### PR DESCRIPTION
 - Edited smart_reslim6 to smart_reslim5
 - Edited semiannuals (only) to use this 

This should improve mid-range data loading in Terria.