### PR TITLE
Ows translation

### DIFF
--- a/.github/workflows/ows-config-test-build.yaml
+++ b/.github/workflows/ows-config-test-build.yaml
@@ -77,12 +77,66 @@ jobs:
       run: |    
         docker-compose -f docker-compose.ows.yaml down
 
+  upload-translation:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Python environment
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install poeditor
+          mkdir output
+
+      - name: Prepare the DB
+        run: |
+          docker-compose -f docker-compose.ows.yaml up -d
+          docker-compose -f docker-compose.ows.yaml exec -T ows datacube system init
+          docker-compose -f docker-compose.ows.yaml exec -T ows datacube-ows-update --schema --role postgres
+
+      - name: Generate English Terms translation file
+        run: |
+          docker-compose -f docker-compose.ows.yaml exec \
+            -e DATACUBE_OWS_CFG=ows_refactored.prod_af_ows_root_cfg.ows_cfg \
+            -T ows \
+            datacube-ows-cfg extract -m /env/config/output/messages.po
+
+      - name: Upload terms to POEditor.com
+        env:
+          POEDITOR_API_TOKEN: ${{ secrets.POEDITOR_API_TOKEN }}
+          POEDITOR_PROJECT_ID: "471013"
+        run: |
+          python .github/workflows/scripts/upload-po.py
+
+      - name: Remove the DB
+        run: |
+          docker-compose -f docker-compose.ows.yaml down
+
   build-and-push:
     runs-on: ubuntu-latest
     needs: test
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install poeditor
+
+    - name: Download translation from POEditor.com
+      env:
+        POEDITOR_API_TOKEN: ${{ secrets.POEDITOR_API_TOKEN }}
+        POEDITOR_PROJECT_ID: "471013"
+      run: |
+        python .github/workflows/scripts/download-mo.py
 
     - name: Push to DockerHub (master branch or tagged release only)
       if: github.ref == 'refs/heads/master' || github.event_name == 'release'

--- a/.github/workflows/scripts/download-mo.py
+++ b/.github/workflows/scripts/download-mo.py
@@ -1,0 +1,23 @@
+import os
+from pathlib import Path
+from poeditor import POEditorAPI
+
+
+def download_translation(file_path, project_id, api_token):
+    client = POEditorAPI(api_token=api_token)
+
+    os.makedirs(Path(file_path).absolute().parent, exist_ok=True)
+
+    client.export(
+        project_id=project_id,
+        language_code='fr',
+        file_type='mo',
+        local_file=file_path,
+    )
+
+
+if __name__ == '__main__':
+    project_id = os.environ['POEDITOR_PROJECT_ID']
+    api_token = os.environ['POEDITOR_API_TOKEN']
+
+    download_translation('./translations/fr/LC_MESSAGES/ows_cfg.mo', project_id, api_token)

--- a/.github/workflows/scripts/upload-po.py
+++ b/.github/workflows/scripts/upload-po.py
@@ -1,0 +1,32 @@
+import os
+from poeditor import POEditorAPI
+
+
+def upload_terms(file_path, project_id, api_token):
+    client = POEditorAPI(api_token=api_token)
+
+    project = client.view_project_details(project_id)
+    print(f"Before update, {project['name']} (id: {project['id']}) has {project['terms']} terms.")
+
+    update_results = client.update_terms_translations(
+        project_id=project_id,
+        file_path=file_path,
+        language_code='en',
+        overwrite=True,
+        tags='all',
+    )
+
+    terms = update_results['terms']
+    print("Terms updated:")
+    for k, v in terms.items():
+        print(f"\t{k}: {v}")
+
+    project = client.view_project_details(project_id)
+    print(f"After update, {project['name']} (id: {project['id']}) has {project['terms']} terms.")
+
+
+if __name__ == '__main__':
+    project_id = os.environ['POEDITOR_PROJECT_ID']
+    api_token = os.environ['POEDITOR_API_TOKEN']
+
+    upload_terms('output/messages.po', project_id, api_token)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Prod and dev config files are titled accordingly. Note any `/services` additions
  - Edit the appropriate files
  - Merge changes into `/master` branch via a PR
  - Run the appropriate (prod, dev) `ows-update` workflow (external to this repository)
+ - Update the translation: https://poeditor.com/join/project?hash=Iciv4SqUeH
  - Confirm correct deployment to OWS by inspecting the relevant OWS URLs and/or importing them to Terria using the 'My Data' option in the catalogue.
      - Dev: https://ows.dev.digitalearth.africa/
      - Unstable prod: https://ows-latest.digitalearth.africa/ 

--- a/docker-compose.ows.yaml
+++ b/docker-compose.ows.yaml
@@ -24,3 +24,4 @@ services:
     volumes:
       - ./services/ows_refactored:/env/config/ows_refactored/
       - ./services/inventory:/env/config/inventory/
+      - ./output:/env/config/output/

--- a/services/ows_refactored/prod_af_ows_root_cfg.py
+++ b/services/ows_refactored/prod_af_ows_root_cfg.py
@@ -65,6 +65,11 @@ ows_cfg = {
         "access_constraints": "© Commonwealth of Australia (Geoscience Australia) 2018. "
         "This product is released under the Creative Commons Attribution 4.0 International Licence. "
         "http://creativecommons.org/licenses/by/4.0/legalcode",
+        "translations_directory": "/opt/dea-config/translations",
+        "supported_languages": [
+            "en",  # English  - the default language, the language used in the untranslated metadata.
+            "fr",  # French
+        ]
     },  # END OF global SECTION
     "wms": {
         # Config for WMS service, for all products/layers


### PR DESCRIPTION
## Description

This change adds translation for the OWS metadata catalog for the PROD config. 

### Github Action changes
On commit, uploads translatable terms to translation site POEditor.com.
On build/release of docker image, downloads latest compiled French translation file.

### Potential problems:
* Treats POEditor as the single point of truth for translation
* Does not track version translation file when releasing docker image
* Only set up for PROD, not DEV config

Requires `POEDITOR_API_TOKEN` to be added as a repo secret.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test locally

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings