### PR TITLE
Fix translations path

### DIFF
--- a/.github/workflows/ows-config-test-build.yaml
+++ b/.github/workflows/ows-config-test-build.yaml
@@ -109,6 +109,7 @@ jobs:
             datacube-ows-cfg extract -m /env/config/output/messages.po
 
       - name: Upload terms to POEditor.com
+        if: github.ref == 'refs/heads/master' || github.event_name == 'release' || github.event_name == 'pull_request'
         env:
           POEDITOR_API_TOKEN: ${{ secrets.POEDITOR_API_TOKEN }}
           POEDITOR_PROJECT_ID: "471013"

--- a/.github/workflows/scripts/download-mo.py
+++ b/.github/workflows/scripts/download-mo.py
@@ -20,4 +20,4 @@ if __name__ == '__main__':
     project_id = os.environ['POEDITOR_PROJECT_ID']
     api_token = os.environ['POEDITOR_API_TOKEN']
 
-    download_translation('./translations/fr/LC_MESSAGES/ows_cfg.mo', project_id, api_token)
+    download_translation('./services/ows_refactored/translations/fr/LC_MESSAGES/ows_cfg.mo', project_id, api_token)

--- a/services/ows_refactored/prod_af_ows_root_cfg.py
+++ b/services/ows_refactored/prod_af_ows_root_cfg.py
@@ -65,7 +65,7 @@ ows_cfg = {
         "access_constraints": "© Commonwealth of Australia (Geoscience Australia) 2018. "
         "This product is released under the Creative Commons Attribution 4.0 International Licence. "
         "http://creativecommons.org/licenses/by/4.0/legalcode",
-        "translations_directory": "/config/translations",
+        "translations_directory": "/env/config/ows_refactored/translations",
         "supported_languages": [
             "en",  # English  - the default language, the language used in the untranslated metadata.
             "fr",  # French

--- a/services/ows_refactored/prod_af_ows_root_cfg.py
+++ b/services/ows_refactored/prod_af_ows_root_cfg.py
@@ -65,7 +65,7 @@ ows_cfg = {
         "access_constraints": "© Commonwealth of Australia (Geoscience Australia) 2018. "
         "This product is released under the Creative Commons Attribution 4.0 International Licence. "
         "http://creativecommons.org/licenses/by/4.0/legalcode",
-        "translations_directory": "/opt/dea-config/translations",
+        "translations_directory": "/config/translations",
         "supported_languages": [
             "en",  # English  - the default language, the language used in the untranslated metadata.
             "fr",  # French


### PR DESCRIPTION
Set the translation path to be `/env/config/ows_refactored/translations` on production deployment.

Also only uploads the `.po` file on master, PR and releases, to avoid rate limiting on POEditor.com.
