### PR TITLE
remove default_bands config - no longer required

### DIFF
--- a/services/ows_refactored/wofs/ows_wofs_ls_alltime_cfg.py
+++ b/services/ows_refactored/wofs/ows_wofs_ls_alltime_cfg.py
@@ -35,9 +35,6 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
     },
     "native_crs": "EPSG:6933",
     "native_resolution": [30.0, -30.0],
-    "wcs": {
-        "default_bands": ["frequency"],
-    },
     "styling": {
         "default_style": "wofs_summary_alltime_frequency",
         "styles": [

--- a/services/ows_refactored/wofs/ows_wofs_ls_annual_cfg.py
+++ b/services/ows_refactored/wofs/ows_wofs_ls_annual_cfg.py
@@ -35,9 +35,6 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
     },
     "native_crs": "EPSG:6933",
     "native_resolution": [30.0, -30.0],
-    "wcs": {
-        "default_bands": ["frequency", "count_wet", "count_clear"],
-    },
     "styling": {
         "default_style": "wofs_summary_annual_frequency",
         "styles": [


### PR DESCRIPTION
`default_bands` config is deprecated in new ows release so removing it.