### PR TITLE
Add translation (of prod catalog) to dev ows

### DIFF
--- a/services/ows_refactored/dev_af_ows_root_cfg.py
+++ b/services/ows_refactored/dev_af_ows_root_cfg.py
@@ -62,6 +62,11 @@ ows_cfg = {
         "access_constraints": "© Commonwealth of Australia (Geoscience Australia) 2018. "
         "This product is released under the Creative Commons Attribution 4.0 International Licence. "
         "http://creativecommons.org/licenses/by/4.0/legalcode",
+        "translations_directory": "/env/config/ows_refactored/translations",
+        "supported_languages": [
+            "en",  # English  - the default language, the language used in the untranslated metadata.
+            "fr",  # French
+        ],
     },  # END OF global SECTION
     "wms": {
         # Config for WMS service, for all products/layers


### PR DESCRIPTION
Adds french translation to dev ows.
Uses the prod translation, so only terms already in the prod config will be translated.