### PR TITLE
Change dtype of count measurements in NDVI climatology

### DIFF
--- a/products/ndvi_climatology_ls.odc-product.yaml
+++ b/products/ndvi_climatology_ls.odc-product.yaml
@@ -181,82 +181,82 @@ measurements:
     aliases:
       - COUNT_JAN
       - count_january
-    dtype: int8
+    dtype: int16
     nodata: 0
     units: '1'
   - name: count_feb
     aliases:
       - COUNT_FEB
       - count_february
-    dtype: int8
+    dtype: int16
     nodata: 0
     units: '1'
   - name: count_mar
     aliases:
       - COUNT_MAR
       - count_march
-    dtype: int8
+    dtype: int16
     nodata: 0
     units: '1'
   - name: count_apr
     aliases:
       - COUNT_APR
       - count_april
-    dtype: int8
+    dtype: int16
     nodata: 0
     units: '1'
   - name: count_may
     aliases:
       - COUNT_MAY
-    dtype: int8
+    dtype: int16
     nodata: 0
     units: '1'
   - name: count_jun
     aliases:
       - COUNT_JUN
       - count_june
-    dtype: int8
+    dtype: int16
     nodata: 0
     units: '1'
   - name: count_jul
     aliases:
       - COUNT_JUL
       - count_july
-    dtype: int8
+    dtype: int16
     nodata: 0
     units: '1'
   - name: count_aug
     aliases:
       - COUNT_AUG
       - count_august
-    dtype: int8
+    dtype: int16
     nodata: 0
     units: '1'
   - name: count_sep
     aliases:
       - COUNT_SEP
       - count_september
-    dtype: int8
+    dtype: int16
     nodata: 0
     units: '1'
   - name: count_oct
     aliases:
       - COUNT_OCT
       - count_october
-    dtype: int8
+    dtype: int16
     nodata: 0
     units: '1'
   - name: count_nov
     aliases:
       - COUNT_NOV
       - count_november
-    dtype: int8
+    dtype: int16
     nodata: 0
     units: '1'
   - name: count_dec
     aliases:
       - COUNT_DEC
       - count_december
-    dtype: int8
+    dtype: int16
     nodata: 0
     units: '1'

--- a/products/ndvi_climatology_ls.odc-product.yaml
+++ b/products/ndvi_climatology_ls.odc-product.yaml
@@ -1,3 +1,4 @@
+---
 name: ndvi_climatology_ls
 description: Monthly NDVI Climatologies produced by Digital Earth Africa.
 metadata_type: eo3
@@ -182,81 +183,81 @@ measurements:
       - COUNT_JAN
       - count_january
     dtype: int16
-    nodata: 0
+    nodata: -999
     units: '1'
   - name: count_feb
     aliases:
       - COUNT_FEB
       - count_february
     dtype: int16
-    nodata: 0
+    nodata: -999
     units: '1'
   - name: count_mar
     aliases:
       - COUNT_MAR
       - count_march
     dtype: int16
-    nodata: 0
+    nodata: -999
     units: '1'
   - name: count_apr
     aliases:
       - COUNT_APR
       - count_april
     dtype: int16
-    nodata: 0
+    nodata: -999
     units: '1'
   - name: count_may
     aliases:
       - COUNT_MAY
     dtype: int16
-    nodata: 0
+    nodata: -999
     units: '1'
   - name: count_jun
     aliases:
       - COUNT_JUN
       - count_june
     dtype: int16
-    nodata: 0
+    nodata: -999
     units: '1'
   - name: count_jul
     aliases:
       - COUNT_JUL
       - count_july
     dtype: int16
-    nodata: 0
+    nodata: -999
     units: '1'
   - name: count_aug
     aliases:
       - COUNT_AUG
       - count_august
     dtype: int16
-    nodata: 0
+    nodata: -999
     units: '1'
   - name: count_sep
     aliases:
       - COUNT_SEP
       - count_september
     dtype: int16
-    nodata: 0
+    nodata: -999
     units: '1'
   - name: count_oct
     aliases:
       - COUNT_OCT
       - count_october
     dtype: int16
-    nodata: 0
+    nodata: -999
     units: '1'
   - name: count_nov
     aliases:
       - COUNT_NOV
       - count_november
     dtype: int16
-    nodata: 0
+    nodata: -999
     units: '1'
   - name: count_dec
     aliases:
       - COUNT_DEC
       - count_december
     dtype: int16
-    nodata: 0
+    nodata: -999
     units: '1'


### PR DESCRIPTION
The datatype of the 'clear count' measurements in the NDVI climatology product was set to `int8`, which was not large enough for some of the pixels which had >128 observations. This PR will fix the dtype in the product definition for the clear count measurements.  

DO NOT MERGE: the data itself will need to be reprocessed, this PR is in anticipation of re-running the data in early 2022 