### PR TITLE
Add WCS/Export functionality to WMS layers

### DIFF
--- a/terria/africa-prod.json
+++ b/terria/africa-prod.json
@@ -10,7 +10,10 @@
           "opacity": 1.0
         },
         "excludeMembers": [],
-        "isOpen": true
+        "isOpen": true,
+        "perLayerLinkedWcs": {
+            "linkedWcsUrl": "https://ows.digitalearth.africa/"
+        }
     }
   ],
   "corsDomains": [


### PR DESCRIPTION
Add

```json
"perLayerLinkedWcs": {
    "linkedWcsUrl": "https://ows.digitalearth.africa/"
}
```

to the root WMS group. This enabled WCS/Export functionality for **all** WMS layers. This will use WMS `Layer.Name` as WCS `coverageId`. See https://github.com/TerriaJS/terriajs/pull/6108 for more info

## Test link

https://maps.digitalearth.africa/#clean&https://raw.githubusercontent.com/digitalearthafrica/config/90d8c5045c500e70c80f6d78f0d00031c774a01e/terria/africa-prod.json

