### PR TITLE
enable show_legend for legacy_style_wofs_summary_alltime

### DIFF
--- a/services/ows_refactored/wofs/style_wofs_ls_legacy.py
+++ b/services/ows_refactored/wofs/style_wofs_ls_legacy.py
@@ -68,6 +68,7 @@ legacy_style_wofs_summary_alltime_frequency = {
         {"value": 1.0, "color": "#5700e3"},
     ],
     "legend": {
+        "show_legend": True,
         "url": "https://data.dea.ga.gov.au/WOfS/filtered_summary/v2.1.0/wofs_full_summary_legend.png",
     },
 }


### PR DESCRIPTION
ows web conformance test is failing with below error so happing that this change fix it.

```
ERROR:root:Request to legend URL https://ows.dev.digitalearth.africa/legend/wofs_ls_summary_alltime/legacy_wofs_summary_alltime_frequency/legend.png 
for layer 'wofs_ls_summary_alltime', style 'legacy_wofs_summary_alltime_frequency' returned a non 200 status of 500 Server 

Error: Internal Server Error for url: https://ows.dev.digitalearth.africa/legend/wofs_ls_summary_alltime/legacy_wofs_summary_alltime_frequency/legend.png.  

WMS URL [https://ows.dev.digitalearth.africa,](https://ows.dev.digitalearth.africa%2C/) version 1.3.0.
```