### PR TITLE
Attempt to fix missing dashed shorelines

### DIFF
--- a/geoserver/geoserver_data/collections/coastline_v0.3.0/styles/coastlines.sld
+++ b/geoserver/geoserver_data/collections/coastline_v0.3.0/styles/coastlines.sld
@@ -18,8 +18,10 @@
                     <sld:MaxScaleDenominator>30000.0</sld:MaxScaleDenominator>
                     <sld:LineSymbolizer>
                         <sld:Stroke>
+                            <sld:CssParameter name="stroke">#000004</sld:CssParameter>
                             <sld:CssParameter name="stroke-linecap">square</sld:CssParameter>
                             <sld:CssParameter name="stroke-linejoin">bevel</sld:CssParameter>
+                            <sld:CssParameter name="stroke-width">2</sld:CssParameter>
                         </sld:Stroke>
                     </sld:LineSymbolizer>
                 </sld:Rule>
@@ -560,8 +562,10 @@
                     <sld:MaxScaleDenominator>30000.0</sld:MaxScaleDenominator>
                     <sld:LineSymbolizer>
                         <sld:Stroke>
+                            <sld:CssParameter name="stroke">#000004</sld:CssParameter>
                             <sld:CssParameter name="stroke-linecap">square</sld:CssParameter>
                             <sld:CssParameter name="stroke-linejoin">bevel</sld:CssParameter>
+                            <sld:CssParameter name="stroke-dasharray">4.0 2.0</sld:CssParameter>
                         </sld:Stroke>
                     </sld:LineSymbolizer>
                 </sld:Rule>


### PR DESCRIPTION
Some Coastlines annual shorelines are not currently plotting with dashed lines correctly. For example, here's a location in the Coastlines GeoPackage (top), and the same location in the GeoServer WMS (bottom):

![image](https://user-images.githubusercontent.com/17680388/183355057-0dab0ecd-30b1-4b9d-a4fb-660d9944a264.png)

![image](https://user-images.githubusercontent.com/17680388/183355083-01f4ad39-228f-44ad-82a4-3fb27dfd7d85.png)


My guess is that this is because the style includes a "Low quality shorelines" rule doesn't include the "stroke-dasharray" bit in the sections below, so that layer is being shown under all of the other data, making it look like the lines are solid.

e.g. this:
https://github.com/digitalearthafrica/config/blob/master/geoserver/geoserver_data/collections/coastline_v0.3.0/styles/coastlines.sld#L561-L566

v.s. this:
https://github.com/digitalearthafrica/config/blob/master/geoserver/geoserver_data/collections/coastline_v0.3.0/styles/coastlines.sld#L584-L591

This PR is a test at fixing this issue by copying the styles of dashed/undashed lines into each of the "Low quality shorelines" and "Good quality shorelines" rules.