### PR TITLE
More appropriate native CRS and resolution for Sentinel-2 daily layer.

### DIFF
--- a/services/ows_refactored/surface_reflectance/ows_s2_cfg.py
+++ b/services/ows_refactored/surface_reflectance/ows_s2_cfg.py
@@ -28,8 +28,8 @@ This product is accessible through OGC Web Service (https://ows.digitalearth.afr
         "manual_merge": False,  # True
         "apply_solar_corrections": False,
     },
-    "native_crs": "EPSG:3857",
-    "native_resolution": [30.0, -30.0],
+    "native_crs": "EPSG:6933",
+    "native_resolution": [10.0, -10.0],
     "styling": {
         "default_style": "simple_rgb",
         "styles": styles_s2_list,


### PR DESCRIPTION
A user reported pixel alignment issues from WCS2 requests against the s2_l2a layer: [datacube-ows#872](https://github.com/opendatacube/datacube-ows/issues/872)

This issue is due to the native resolution being configured to 30m pixels instead of 10m pixels.  Additionally EPSG:3857 (Web Mercator) was configured as the native CRS, instead of a more appropriate equal-area projection.

This PR fixes both issues.