### PR TITLE
Add certainty sorting to rates of change

### DIFF
--- a/geoserver/geoserver_data/collections/coastlines/styles/coastlines_v0.4.0_rates_of_change.sld
+++ b/geoserver/geoserver_data/collections/coastlines/styles/coastlines_v0.4.0_rates_of_change.sld
@@ -665,7 +665,7 @@
                         <sld:Priority>100</sld:Priority>
                     </sld:TextSymbolizer>
                 </sld:Rule>
-                <sld:VendorOption name="sortBy">wms_sig A, wms_abs A</sld:VendorOption>
+                <sld:VendorOption name="sortBy">wms_sig A, wms_good A, wms_abs A</sld:VendorOption>
             </sld:FeatureTypeStyle>
         </sld:UserStyle>
     </sld:NamedLayer>


### PR DESCRIPTION
A very minor update to add sorting by certainty to the rates of change points. This puts the uncertain white points underneath the certain coloured points.

Before:
![image](https://user-images.githubusercontent.com/17680388/196821868-2e55012b-85f6-4434-818e-73f02a3a4733.png)

After:
![image](https://user-images.githubusercontent.com/17680388/196821966-2ce862e8-234a-4ba3-9e9e-ce7bdee2c144.png)

