### PR TITLE
Updated s2_l2a product

### DIFF
--- a/products/esa_s2_l2a.odc-product.yaml
+++ b/products/esa_s2_l2a.odc-product.yaml
@@ -9,80 +9,80 @@ metadata:
     name: s2_l2a
 
 measurements:
-  - name: "B01"
-    aliases: [band_01, coastal_aerosol]
+  - name: "coastal"
+    aliases: [band_01, coastal_aerosol, B01]
     units: "1"
     dtype: uint16
     nodata: 0
 
-  - name: "B02"
-    aliases: [band_02, blue]
+  - name: "blue"
+    aliases: [band_02, B02]
     units: "1"
     dtype: uint16
     nodata: 0
 
-  - name: "B03"
-    aliases: [band_03, green]
+  - name: "green"
+    aliases: [band_03, B03]
     units: "1"
     dtype: uint16
     nodata: 0
 
-  - name: "B04"
-    aliases: [band_04, red]
+  - name: "red"
+    aliases: [band_04, B04]
     units: "1"
     dtype: uint16
     nodata: 0
 
-  - name: "B05"
-    aliases: [band_05, red_edge_1]
+  - name: "rededge1"
+    aliases: [band_05, red_edge_1, B05]
     units: "1"
     dtype: uint16
     nodata: 0
 
-  - name: "B06"
-    aliases: [band_06, red_edge_2]
+  - name: "rededge2"
+    aliases: [band_06, red_edge_2, B06]
     units: "1"
     dtype: uint16
     nodata: 0
 
-  - name: "B07"
-    aliases: [band_07, red_edge_3]
+  - name: "rededge3"
+    aliases: [band_07, red_edge_3, B07]
     units: "1"
     dtype: uint16
     nodata: 0
 
-  - name: "B08"
-    aliases: [band_08, nir, nir_1]
+  - name: "nir"
+    aliases: [band_08, nir_1, B08]
     units: "1"
     dtype: uint16
     nodata: 0
 
-  - name: "B8A"
-    aliases: [band_8a, nir_narrow, nir_2]
+  - name: "nir08"
+    aliases: [band_8a, nir_narrow, nir_2, B8A]
     units: "1"
     dtype: uint16
     nodata: 0
 
-  - name: "B09"
-    aliases: [band_09, water_vapour]
+  - name: "nir09"
+    aliases: [band_09, water_vapour, B09]
     units: "1"
     dtype: uint16
     nodata: 0
 
-  - name: "B11"
-    aliases: [band_11, swir_1, swir_16]
+  - name: "swir16"
+    aliases: [band_11, swir_1, swir_16, B11]
     units: "1"
     dtype: uint16
     nodata: 0
 
-  - name: "B12"
-    aliases: [band_12, swir_2, swir_22]
+  - name: "swir22"
+    aliases: [band_12, swir_2, swir_22, B12]
     units: "1"
     dtype: uint16
     nodata: 0
 
-  - name: "SCL"
-    aliases: [mask, qa]
+  - name: "scl"
+    aliases: [mask, qa, SCL]
     units: "1"
     dtype: uint8
     nodata: 0
@@ -104,14 +104,14 @@ measurements:
           10: thin cirrus
           11: snow or ice
 
-  - name: "AOT"
-    aliases: [aerosol_optical_thickness]
+  - name: "aot"
+    aliases: [aerosol_optical_thickness, AOT]
     units: "1"
     dtype: uint16
     nodata: 0
 
-  - name: "WVP"
-    aliases: [scene_average_water_vapour]
+  - name: "wvp"
+    aliases: [scene_average_water_vapour WVP]
     units: "1"
     dtype: uint16
     nodata: 0


### PR DESCRIPTION
Updated s2_l2a product to match v1 of Element84 STAC Catalog.

Related PR, necessary to use this new product def:

https://github.com/opendatacube/odc-tools/pull/591

Related issues:

https://github.com/opendatacube/cube-in-a-box/issues/64

https://github.com/opendatacube/datacube-dataset-config/issues/39