### PR TITLE
Make surface water products hierarchy and names consistent

### DIFF
--- a/services/ows_refactored/prod_af_ows_root_cfg.py
+++ b/services/ows_refactored/prod_af_ows_root_cfg.py
@@ -147,8 +147,8 @@ ows_cfg = {
                             ],
                         },
                         {
-                            "title": "Surface water",
-                            "abstract": """Surface water""",
+                            "title": "Surface Water - Water Observations",
+                            "abstract": """Surface Water - Water Observations""",
                             "layers": [
                                 {
                                     "title": "Water Observations from Space (WOfS)",
@@ -168,6 +168,12 @@ ows_cfg = {
                                         },
                                     ],
                                 },
+                            ],
+                        },
+                        {
+                            "title": "Surface Water - Water Quality",
+                            "abstract": """Surface Water - Water Quality""",
+                            "layers": [
                                 {
                                     "title": "Water Quality Monitoring Service (WQMS)",
                                     "abstract": """Water Quality Monitoring Service (WQMS)""",

--- a/terria/africa-prod.json
+++ b/terria/africa-prod.json
@@ -69,7 +69,7 @@
             },
             {
               "type": "group",
-              "name": "Surface water - waterbodies",
+              "name": "Surface water - Waterbodies",
               "members": [
                 {
                   "type": "wms",

--- a/terria/africa-prod.json
+++ b/terria/africa-prod.json
@@ -69,7 +69,7 @@
             },
             {
               "type": "group",
-              "name": "Surface water - Waterbodies",
+              "name": "Surface Water - Waterbodies",
               "members": [
                 {
                   "type": "wms",


### PR DESCRIPTION
Currently, Waterbodies on Maps sits in its own folder since it's drawn from geoserver, whereas Water Observations and Water Quality sit under the 'Surface water' folder (please find image below). This PR separates out Water Observations and Water Quality like Waterbodies for consistency, and makes all names title case.

Ideally all three products would sit under Surface water. However, this is not possible as I currently understanding due to Waterbodies being drawn in from a different source, geoserver.

<img width="482" height="410" alt="image" src="https://github.com/user-attachments/assets/b72972d6-0bc1-4cdf-addc-e56ea9a29752" />