### PR TITLE
Update IWMI number of rainydays product measurements

### DIFF
--- a/products/iwmi_number_of_rainydays_monthly.odc-product.yaml
+++ b/products/iwmi_number_of_rainydays_monthly.odc-product.yaml
@@ -17,4 +17,5 @@ measurements:
     dtype: int16
     nodata: -9999
     units: "count"
+    scale_factor: 0.1
     aliases: [nRD]


### PR DESCRIPTION
This PR adds a new measurement `scale_factor: 0.1` to IWMI nRD product definition.