### PR TITLE
Geomad lowres from master

### DIFF
--- a/services/inventory/dev_af/inventory.json
+++ b/services/inventory/dev_af/inventory.json
@@ -1,5 +1,5 @@
 {
-    "total_layers_count": 51,
+    "total_layers_count": 56,
     "layers": [
         {
             "layer": "s2_l2a",
@@ -256,6 +256,146 @@
             "layer": "gm_s2_rolling",
             "product": [
                 "gm_s2_rolling"
+            ],
+            "styles_count": 22,
+            "styles_list": [
+                "simple_rgb",
+                "infrared_green",
+                "tmad_rgb_std",
+                "tmad_rgb_sens",
+                "ndvi",
+                "ndwi",
+                "mndwi",
+                "ndci",
+                "blue",
+                "green",
+                "red",
+                "red_edge_1",
+                "red_edge_2",
+                "red_edge_3",
+                "nir",
+                "narrow_nir",
+                "swir_1",
+                "swir_2",
+                "arcsec_sdev",
+                "log_edev",
+                "log_bcdev",
+                "count"
+            ]
+        },
+        {
+            "layer": "gm_s2_annual_lowres",
+            "product": [
+                "gm_s2_annual_lowres"
+            ],
+            "styles_count": 22,
+            "styles_list": [
+                "simple_rgb",
+                "infrared_green",
+                "tmad_rgb_std",
+                "tmad_rgb_sens",
+                "ndvi",
+                "ndwi",
+                "mndwi",
+                "ndci",
+                "blue",
+                "green",
+                "red",
+                "red_edge_1",
+                "red_edge_2",
+                "red_edge_3",
+                "nir",
+                "narrow_nir",
+                "swir_1",
+                "swir_2",
+                "arcsec_sdev",
+                "log_edev",
+                "log_bcdev",
+                "count"
+            ]
+        },
+        {
+            "layer": "gm_ls8_annual_lowres",
+            "product": [
+                "gm_ls8_annual_lowres"
+            ],
+            "styles_count": 17,
+            "styles_list": [
+                "simple_rgb",
+                "infrared_green",
+                "tmad_rgb_std",
+                "tmad_rgb_sens",
+                "ndvi",
+                "ndwi",
+                "mndwi",
+                "blue",
+                "green",
+                "red",
+                "nir",
+                "swir_1",
+                "swir_2",
+                "arcsec_sdev",
+                "log_edev",
+                "log_bcdev",
+                "count"
+            ]
+        },
+        {
+            "layer": "gm_ls8_ls9_annual_lowres",
+            "product": [
+                "gm_ls8_ls9_annual_lowres"
+            ],
+            "styles_count": 17,
+            "styles_list": [
+                "simple_rgb",
+                "infrared_green",
+                "tmad_rgb_std",
+                "tmad_rgb_sens",
+                "ndvi",
+                "ndwi",
+                "mndwi",
+                "blue",
+                "green",
+                "red",
+                "nir",
+                "swir_1",
+                "swir_2",
+                "arcsec_sdev",
+                "log_edev",
+                "log_bcdev",
+                "count"
+            ]
+        },
+        {
+            "layer": "gm_ls5_ls7_annual_lowres",
+            "product": [
+                "gm_ls5_ls7_annual_lowres"
+            ],
+            "styles_count": 17,
+            "styles_list": [
+                "simple_rgb",
+                "infrared_green",
+                "tmad_rgb_std",
+                "tmad_rgb_sens",
+                "ndvi",
+                "ndwi",
+                "mndwi",
+                "blue",
+                "green",
+                "red",
+                "nir",
+                "swir_1",
+                "swir_2",
+                "arcsec_sdev",
+                "log_edev",
+                "log_bcdev",
+                "count"
+            ]
+        },
+        {
+            "layer": "gm_s2_semiannual_lowres",
+            "product": [
+                "gm_s2_semiannual_lowres"
             ],
             "styles_count": 22,
             "styles_list": [

--- a/services/ows_refactored/common/ows_reslim_cfg.py
+++ b/services/ows_refactored/common/ows_reslim_cfg.py
@@ -153,3 +153,19 @@ reslim_wofs_dry = {
 reslim_alos_palsar = reslim_continental
 
 reslim_land_cover = reslim_continental
+
+# Low-res summary layers (gm_*_lowres). Tiny dataset count continentally
+# (~5-29 datasets), so no zoom guard is needed -- let them render at every
+# zoom instead of drawing the zoomed-out placeholder. Only affects direct
+# requests to these (hidden) layers; the parent layers' low_res_product_name
+# substitution is governed by the parent's own resource_limits, not this.
+reslim_lowres = {
+    "wms": {
+        "zoomed_out_fill_colour": [150, 180, 200, 160],
+        "min_zoom_factor": 0.0,
+        "dataset_cache_rules": dataset_cache_rules,
+    },
+    "wcs": {
+        "max_datasets": 32,  # Defaults to no dataset limit
+    },
+}

--- a/services/ows_refactored/dev_af_ows_root_cfg.py
+++ b/services/ows_refactored/dev_af_ows_root_cfg.py
@@ -145,6 +145,32 @@ ows_cfg = {
                                     "include": "ows_refactored.surface_reflectance.ows_gm_s2_rolling_cfg.layer",
                                     "type": "python",
                                 },
+                                # Low-resolution summary layers. Configured as named
+                                # layers so datacube-ows-update generates product_ranges
+                                # for them, enabling the parent layers' low_res_product_name
+                                # substitution at continental zoom. They carry "hide": True
+                                # (no-op until OWS is upgraded past 1.8.42, so they are
+                                # currently visible in GetCapabilities on Dev).
+                                {
+                                    "include": "ows_refactored.surface_reflectance.ows_gm_s2_annual_cfg.lowres_layer",
+                                    "type": "python",
+                                },
+                                {
+                                    "include": "ows_refactored.surface_reflectance.ows_gm_ls8_annual_cfg.lowres_layer",
+                                    "type": "python",
+                                },
+                                {
+                                    "include": "ows_refactored.surface_reflectance.ows_gm_ls8_ls9_annual_cfg.lowres_layer",
+                                    "type": "python",
+                                },
+                                {
+                                    "include": "ows_refactored.surface_reflectance.ows_gm_ls5_ls7_annual_cfg.lowres_layer",
+                                    "type": "python",
+                                },
+                                {
+                                    "include": "ows_refactored.surface_reflectance.ows_gm_s2_semiannual_cfg.lowres_layer",
+                                    "type": "python",
+                                },
                             ],
                         },
                         {

--- a/services/ows_refactored/surface_reflectance/ows_gm_ls5_ls7_annual_cfg.py
+++ b/services/ows_refactored/surface_reflectance/ows_gm_ls5_ls7_annual_cfg.py
@@ -1,4 +1,4 @@
-from ows_refactored.common.ows_reslim_cfg import reslim_continental
+from ows_refactored.common.ows_reslim_cfg import reslim_continental, reslim_lowres
 from ows_refactored.surface_reflectance.band_sr_cfg import bands_ls5_ls7_gm
 from ows_refactored.surface_reflectance.style_sr_cfg import styles_gm_ls5789_list
 
@@ -69,7 +69,7 @@ lowres_layer = {
     "hide": True,
     "bands": bands_ls5_ls7_gm,
     "dynamic": False,
-    "resource_limits": reslim_continental,
+    "resource_limits": reslim_lowres,
     "time_resolution": "year",
     "image_processing": {
         "extent_mask_func": "ows_refactored.common.ows_util_tools.mask_by_emad_nan",

--- a/services/ows_refactored/surface_reflectance/ows_gm_ls5_ls7_annual_cfg.py
+++ b/services/ows_refactored/surface_reflectance/ows_gm_ls5_ls7_annual_cfg.py
@@ -53,3 +53,34 @@ For more information on the algorithm, see https://doi.org/10.1109/TGRS.2017.272
         "styles": styles_gm_ls5789_list,
     }
 }
+
+# Standalone layer for the low-resolution summary product.
+# datacube-ows-update only generates product_ranges for products that are
+# configured as named layers, so the parent layer's low_res_product_name
+# substitution never kicks in until this layer exists and has ranges.
+# NOTE: "hide" is a no-op on the deployed OWS 1.8.42 (the key is not read from
+# layer config until 1.9.x), so on Dev this layer WILL appear in
+# GetCapabilities. Kept for forward-compatibility once OWS is upgraded.
+lowres_layer = {
+    "title": "Annual GeoMAD (Landsat 5 & Landsat 7) - Low Resolution",
+    "name": "gm_ls5_ls7_annual_lowres",
+    "abstract": "Low-resolution summary mosaic of the Annual GeoMAD (Landsat 5 & Landsat 7). Used by OWS to serve gm_ls5_ls7_annual at low (continental) zoom levels.",
+    "product_name": "gm_ls5_ls7_annual_lowres",
+    "hide": True,
+    "bands": bands_ls5_ls7_gm,
+    "dynamic": False,
+    "resource_limits": reslim_continental,
+    "time_resolution": "year",
+    "image_processing": {
+        "extent_mask_func": "ows_refactored.common.ows_util_tools.mask_by_emad_nan",
+        "always_fetch_bands": ["EMAD"],
+        "manual_merge": False,
+        "apply_solar_corrections": False,
+    },
+    "native_crs": "EPSG:6933",
+    "native_resolution": [30.0, -30.0],
+    "styling": {
+        "default_style": "simple_rgb",
+        "styles": styles_gm_ls5789_list,
+    }
+}

--- a/services/ows_refactored/surface_reflectance/ows_gm_ls8_annual_cfg.py
+++ b/services/ows_refactored/surface_reflectance/ows_gm_ls8_annual_cfg.py
@@ -1,4 +1,4 @@
-from ows_refactored.common.ows_reslim_cfg import reslim_continental
+from ows_refactored.common.ows_reslim_cfg import reslim_continental, reslim_lowres
 from ows_refactored.surface_reflectance.band_sr_cfg import bands_ls8_gm
 from ows_refactored.surface_reflectance.style_sr_cfg import styles_gm_ls5789_list
 
@@ -69,7 +69,7 @@ lowres_layer = {
     "hide": True,
     "bands": bands_ls8_gm,
     "dynamic": False,
-    "resource_limits": reslim_continental,
+    "resource_limits": reslim_lowres,
     "time_resolution": "year",
     "image_processing": {
         "extent_mask_func": "ows_refactored.common.ows_util_tools.mask_by_emad_nan",

--- a/services/ows_refactored/surface_reflectance/ows_gm_ls8_annual_cfg.py
+++ b/services/ows_refactored/surface_reflectance/ows_gm_ls8_annual_cfg.py
@@ -53,3 +53,34 @@ For more information on the algorithm, see https://doi.org/10.1109/TGRS.2017.272
         "styles": styles_gm_ls5789_list,
     }
 }
+
+# Standalone layer for the low-resolution summary product.
+# datacube-ows-update only generates product_ranges for products that are
+# configured as named layers, so the parent layer's low_res_product_name
+# substitution never kicks in until this layer exists and has ranges.
+# NOTE: "hide" is a no-op on the deployed OWS 1.8.42 (the key is not read from
+# layer config until 1.9.x), so on Dev this layer WILL appear in
+# GetCapabilities. Kept for forward-compatibility once OWS is upgraded.
+lowres_layer = {
+    "title": "Annual GeoMAD (Landsat 8) - Low Resolution",
+    "name": "gm_ls8_annual_lowres",
+    "abstract": "Low-resolution summary mosaic of the Annual GeoMAD (Landsat 8). Used by OWS to serve gm_ls8_annual at low (continental) zoom levels.",
+    "product_name": "gm_ls8_annual_lowres",
+    "hide": True,
+    "bands": bands_ls8_gm,
+    "dynamic": False,
+    "resource_limits": reslim_continental,
+    "time_resolution": "year",
+    "image_processing": {
+        "extent_mask_func": "ows_refactored.common.ows_util_tools.mask_by_emad_nan",
+        "always_fetch_bands": ["EMAD"],
+        "manual_merge": False,
+        "apply_solar_corrections": False,
+    },
+    "native_crs": "EPSG:6933",
+    "native_resolution": [30.0, -30.0],
+    "styling": {
+        "default_style": "simple_rgb",
+        "styles": styles_gm_ls5789_list,
+    }
+}

--- a/services/ows_refactored/surface_reflectance/ows_gm_ls8_ls9_annual_cfg.py
+++ b/services/ows_refactored/surface_reflectance/ows_gm_ls8_ls9_annual_cfg.py
@@ -53,3 +53,34 @@ For more information on the algorithm, see https://doi.org/10.1109/TGRS.2017.272
         "styles": styles_gm_ls5789_list,
     }
 }
+
+# Standalone layer for the low-resolution summary product.
+# datacube-ows-update only generates product_ranges for products that are
+# configured as named layers, so the parent layer's low_res_product_name
+# substitution never kicks in until this layer exists and has ranges.
+# NOTE: "hide" is a no-op on the deployed OWS 1.8.42 (the key is not read from
+# layer config until 1.9.x), so on Dev this layer WILL appear in
+# GetCapabilities. Kept for forward-compatibility once OWS is upgraded.
+lowres_layer = {
+    "title": "Annual GeoMAD (Landsat 8 & Landsat 9) - Low Resolution",
+    "name": "gm_ls8_ls9_annual_lowres",
+    "abstract": "Low-resolution summary mosaic of the Annual GeoMAD (Landsat 8 & Landsat 9). Used by OWS to serve gm_ls8_ls9_annual at low (continental) zoom levels.",
+    "product_name": "gm_ls8_ls9_annual_lowres",
+    "hide": True,
+    "bands": bands_ls8_ls9_gm,
+    "dynamic": False,
+    "resource_limits": reslim_continental,
+    "time_resolution": "year",
+    "image_processing": {
+        "extent_mask_func": "ows_refactored.common.ows_util_tools.mask_by_emad_nan",
+        "always_fetch_bands": ["EMAD"],
+        "manual_merge": False,
+        "apply_solar_corrections": False,
+    },
+    "native_crs": "EPSG:6933",
+    "native_resolution": [30.0, -30.0],
+    "styling": {
+        "default_style": "simple_rgb",
+        "styles": styles_gm_ls5789_list,
+    }
+}

--- a/services/ows_refactored/surface_reflectance/ows_gm_ls8_ls9_annual_cfg.py
+++ b/services/ows_refactored/surface_reflectance/ows_gm_ls8_ls9_annual_cfg.py
@@ -1,4 +1,4 @@
-from ows_refactored.common.ows_reslim_cfg import reslim_continental
+from ows_refactored.common.ows_reslim_cfg import reslim_continental, reslim_lowres
 from ows_refactored.surface_reflectance.band_sr_cfg import bands_ls8_ls9_gm
 from ows_refactored.surface_reflectance.style_sr_cfg import styles_gm_ls5789_list
 
@@ -69,7 +69,7 @@ lowres_layer = {
     "hide": True,
     "bands": bands_ls8_ls9_gm,
     "dynamic": False,
-    "resource_limits": reslim_continental,
+    "resource_limits": reslim_lowres,
     "time_resolution": "year",
     "image_processing": {
         "extent_mask_func": "ows_refactored.common.ows_util_tools.mask_by_emad_nan",

--- a/services/ows_refactored/surface_reflectance/ows_gm_s2_annual_cfg.py
+++ b/services/ows_refactored/surface_reflectance/ows_gm_s2_annual_cfg.py
@@ -1,4 +1,4 @@
-from ows_refactored.common.ows_reslim_cfg import reslim_smart5
+from ows_refactored.common.ows_reslim_cfg import reslim_smart5, reslim_lowres
 from ows_refactored.surface_reflectance.band_sr_cfg import bands_s2_gm
 from ows_refactored.surface_reflectance.style_sr_cfg import styles_gm_list
 
@@ -69,7 +69,7 @@ lowres_layer = {
     "hide": True,
     "bands": bands_s2_gm,
     "dynamic": False,
-    "resource_limits": reslim_smart5,
+    "resource_limits": reslim_lowres,
     "time_resolution": "year",
     "image_processing": {
         "extent_mask_func": "ows_refactored.common.ows_util_tools.mask_by_emad_nan",

--- a/services/ows_refactored/surface_reflectance/ows_gm_s2_annual_cfg.py
+++ b/services/ows_refactored/surface_reflectance/ows_gm_s2_annual_cfg.py
@@ -53,3 +53,34 @@ For more information on the algorithm, see https://doi.org/10.1109/TGRS.2017.272
         "styles": styles_gm_list,
     }
 }
+
+# Standalone layer for the low-resolution summary product.
+# datacube-ows-update only generates product_ranges for products that are
+# configured as named layers, so the parent layer's low_res_product_name
+# substitution never kicks in until this layer exists and has ranges.
+# NOTE: "hide" is a no-op on the deployed OWS 1.8.42 (the key is not read from
+# layer config until 1.9.x), so on Dev this layer WILL appear in
+# GetCapabilities. Kept for forward-compatibility once OWS is upgraded.
+lowres_layer = {
+    "title": "Annual GeoMAD (Sentinel-2) - Low Resolution",
+    "name": "gm_s2_annual_lowres",
+    "abstract": "Low-resolution summary mosaic of the Annual GeoMAD (Sentinel-2). Used by OWS to serve gm_s2_annual at low (continental) zoom levels.",
+    "product_name": "gm_s2_annual_lowres",
+    "hide": True,
+    "bands": bands_s2_gm,
+    "dynamic": False,
+    "resource_limits": reslim_smart5,
+    "time_resolution": "year",
+    "image_processing": {
+        "extent_mask_func": "ows_refactored.common.ows_util_tools.mask_by_emad_nan",
+        "always_fetch_bands": ["EMAD"],
+        "manual_merge": False,
+        "apply_solar_corrections": False,
+    },
+    "native_crs": "EPSG:6933",
+    "native_resolution": [10.0, -10.0],
+    "styling": {
+        "default_style": "simple_rgb",
+        "styles": styles_gm_list,
+    }
+}

--- a/services/ows_refactored/surface_reflectance/ows_gm_s2_semiannual_cfg.py
+++ b/services/ows_refactored/surface_reflectance/ows_gm_s2_semiannual_cfg.py
@@ -51,3 +51,34 @@ For more information on the algorithm, see https://doi.org/10.1109/TGRS.2017.272
         "styles": styles_gm_list,
     },
 }
+
+# Standalone layer for the low-resolution summary product.
+# datacube-ows-update only generates product_ranges for products that are
+# configured as named layers, so the parent layer's low_res_product_name
+# substitution never kicks in until this layer exists and has ranges.
+# NOTE: "hide" is a no-op on the deployed OWS 1.8.42 (the key is not read from
+# layer config until 1.9.x), so on Dev this layer WILL appear in
+# GetCapabilities. Kept for forward-compatibility once OWS is upgraded.
+lowres_layer = {
+    "title": "Semiannual GeoMAD (Sentinel-2) - Low Resolution",
+    "name": "gm_s2_semiannual_lowres",
+    "abstract": "Low-resolution summary mosaic of the Semiannual GeoMAD (Sentinel-2). Used by OWS to serve gm_s2_semiannual at low (continental) zoom levels.",
+    "product_name": "gm_s2_semiannual_lowres",
+    "hide": True,
+    "bands": bands_s2_gm,
+    "dynamic": False,
+    "resource_limits": reslim_smart5,
+    "time_resolution": "summary",
+    "image_processing": {
+        "extent_mask_func": "ows_refactored.common.ows_util_tools.mask_by_emad_nan",
+        "always_fetch_bands": ["EMAD"],
+        "manual_merge": False,
+        "apply_solar_corrections": False,
+    },
+    "native_crs": "EPSG:6933",
+    "native_resolution": [10.0, -10.0],
+    "styling": {
+        "default_style": "simple_rgb",
+        "styles": styles_gm_list,
+    },
+}

--- a/services/ows_refactored/surface_reflectance/ows_gm_s2_semiannual_cfg.py
+++ b/services/ows_refactored/surface_reflectance/ows_gm_s2_semiannual_cfg.py
@@ -1,4 +1,4 @@
-from ows_refactored.common.ows_reslim_cfg import reslim_smart5
+from ows_refactored.common.ows_reslim_cfg import reslim_smart5, reslim_lowres
 from ows_refactored.surface_reflectance.band_sr_cfg import bands_s2_gm
 from ows_refactored.surface_reflectance.style_sr_cfg import styles_gm_list
 
@@ -67,7 +67,7 @@ lowres_layer = {
     "hide": True,
     "bands": bands_s2_gm,
     "dynamic": False,
-    "resource_limits": reslim_smart5,
+    "resource_limits": reslim_lowres,
     "time_resolution": "summary",
     "image_processing": {
         "extent_mask_func": "ows_refactored.common.ows_util_tools.mask_by_emad_nan",


### PR DESCRIPTION
#  Test: register low-res GeoMAD layers so they get WMS product_ranges
  (dev)



  ## Hypothesis
  GeoMAD geomedian layers 504 at continental zoom. The parents already
  declare
  `low_res_product_name`, but the substitution never kicks in  because the
  low-res products have **no WMS `product_ranges`**. They have none because
  they aren't named layers in the root config, so `datacube-ows-update` 
  never
  generates ranges for them.

  This PR tests that by registering the `gm_*_lowres` products as (hidden)
  named layers in the **dev** root config so they pick up ranges. **Dev 
  only** —
  prod root config left untouched on purpose while we verify.

  ## Changes
  - Register hidden lowres layers in `dev_af_ows_root_cfg.py`: 
  `gm_s2_annual`,
    `gm_s2_semiannual`, `gm_ls8_annual`, `gm_ls8_ls9_annual`, 
  `gm_ls5_ls7_annual`.
  - `low_res_product_name` set on each parent (`gm_s2_rolling` left 
  commented).
  - `reslim_lowres` profile (`min_zoom_factor: 0.0`) so the tiny lowres 
  products
    (~5–29 datasets) render at every zoom.

  ## Validation plan
  - ✅ All five lowres products are indexed in dev.
  - ⏳ Deploy → run `datacube-ows-update` → confirm the layers now have WMS
    ranges and the parent GeoMAD layers render at continental zoom without 
  504.
  - `"hide": True` is a no-op on OWS 1.8.42, so these layers will show in
    GetCapabilities on dev during the test.

  ---
