### PR TITLE
Pin poeditor to 1.1.3 to fix translation

### DIFF
--- a/.github/workflows/ows-config-test-build.yaml
+++ b/.github/workflows/ows-config-test-build.yaml
@@ -92,7 +92,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install poeditor
+          pip install 'poeditor==1.1.3'
           mkdir output
 
       - name: Prepare the DB
@@ -143,7 +143,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install poeditor
+        pip install 'poeditor==1.1.3'
 
     - name: Download translation from POEditor.com
       env:


### PR DESCRIPTION
#  Pin poeditor to 1.1.3 to fix translation-upload CI



  ## Problem
  The `upload-translation` job has started failing on every PR
  (see screenshot):
<img width="1886" height="929" alt="20260612_14h43m16s_grim" src="https://github.com/user-attachments/assets/67b0db2c-7a1f-4f38-9317-7270c589f8bd" />

  `TypeError: poeditor.client.POEditorAPI._run()
  got multiple values for keyword argument
  'tags'`

  ## Cause
  The workflow installs `poeditor` unpinned, so
  CI now pulls **1.2.0**. That
  release refactored the client into
  `update_terms_translations() -> upload() ->
  _run()`, and `upload()` passes `tags` both via

  ## Problem
  The `upload-translation` job fails on every PR (see screenshot):

  `TypeError: poeditor.client.POEditorAPI._run() got multiple values for keyword argument 'tags'`

  ## Cause
  The workflow installs `poeditor` unpinned, so CI now pulls **1.2.0**. That
  release refactored the client into `update_terms_translations() -> upload() ->
  _run()`, and `upload()` passes `tags` both via `**kwargs` and as an explicit
  `tags=` keyword to `_run()`. Any truthy `tags` triggers the collision —
  `upload-po.py` passes `tags='all'`, so it crashes every run. Unrelated to any
  config change; it breaks all branches.

  ## Fix
  Pin to **1.1.3** (last release before the regression) in both `pip install
  poeditor` steps. Verified its `update_terms_translations(..., tags=...)` and
  `export(...)` signatures still match `upload-po.py` and `download-mo.py`, so no
  script changes needed.

  ## Test
  - [x] `upload-translation` job goes green