### PR TITLE
Fix geomad reslim min zoom factor

### DIFF
--- a/services/ows_refactored/common/ows_reslim_cfg.py
+++ b/services/ows_refactored/common/ows_reslim_cfg.py
@@ -114,6 +114,27 @@ reslim_continental = {
     },
 }
 
+# GeoMAD parent layers (gm_*) that define a low_res_product_name.
+# On a request "zoomed out too far" (zoom_factor < min_zoom_factor) OWS serves
+# the low-res summary product instead of the full-res data. The continental/
+# sub-continental tiles that were timing out (504) sit at zoom_factor ~12-23
+# (regional tiles are ~180), so min_zoom_factor must sit above ~23 to catch
+# them while leaving regional tiles on full-res. zoom_factor is derived from
+# the request bbox/pixel size only (independent of layer native resolution),
+# so the same value applies to both the S2 (10m) and Landsat (30m) geomedians.
+# NB: must be min_zoom_factor (a 1.8.x key) -- min_zoom_level only exists in
+# datacube-ows 1.9.x and is silently ignored on the deployed 1.8.42.
+reslim_geomad = {
+    "wms": {
+        "zoomed_out_fill_colour": [150, 180, 200, 160],
+        "min_zoom_factor": 30.0,
+        "dataset_cache_rules": dataset_cache_rules,
+    },
+    "wcs": {
+        "max_datasets": 32,  # Defaults to no dataset limit
+    },
+}
+
 reslim_wofs = {
     "wms": {
         "zoomed_out_fill_colour": [150, 180, 200, 160],

--- a/services/ows_refactored/surface_reflectance/ows_gm_ls5_ls7_annual_cfg.py
+++ b/services/ows_refactored/surface_reflectance/ows_gm_ls5_ls7_annual_cfg.py
@@ -1,4 +1,4 @@
-from ows_refactored.common.ows_reslim_cfg import reslim_continental, reslim_lowres
+from ows_refactored.common.ows_reslim_cfg import reslim_geomad, reslim_lowres
 from ows_refactored.surface_reflectance.band_sr_cfg import bands_ls5_ls7_gm
 from ows_refactored.surface_reflectance.style_sr_cfg import styles_gm_ls5789_list
 
@@ -37,7 +37,7 @@ For more information on the algorithm, see https://doi.org/10.1109/TGRS.2017.272
     "low_res_product_name": "gm_ls5_ls7_annual_lowres",
     "bands": bands_ls5_ls7_gm,
     "dynamic": False,
-    "resource_limits": reslim_continental,
+    "resource_limits": reslim_geomad,
     "time_resolution": "year",
     "image_processing": {
         "extent_mask_func": "ows_refactored.common.ows_util_tools.mask_by_emad_nan",

--- a/services/ows_refactored/surface_reflectance/ows_gm_ls8_annual_cfg.py
+++ b/services/ows_refactored/surface_reflectance/ows_gm_ls8_annual_cfg.py
@@ -1,4 +1,4 @@
-from ows_refactored.common.ows_reslim_cfg import reslim_continental, reslim_lowres
+from ows_refactored.common.ows_reslim_cfg import reslim_geomad, reslim_lowres
 from ows_refactored.surface_reflectance.band_sr_cfg import bands_ls8_gm
 from ows_refactored.surface_reflectance.style_sr_cfg import styles_gm_ls5789_list
 
@@ -37,7 +37,7 @@ For more information on the algorithm, see https://doi.org/10.1109/TGRS.2017.272
     "low_res_product_name": "gm_ls8_annual_lowres",
     "bands": bands_ls8_gm,
     "dynamic": False,
-    "resource_limits": reslim_continental,
+    "resource_limits": reslim_geomad,
     "time_resolution": "year",
     "image_processing": {
         "extent_mask_func": "ows_refactored.common.ows_util_tools.mask_by_emad_nan",

--- a/services/ows_refactored/surface_reflectance/ows_gm_ls8_ls9_annual_cfg.py
+++ b/services/ows_refactored/surface_reflectance/ows_gm_ls8_ls9_annual_cfg.py
@@ -1,4 +1,4 @@
-from ows_refactored.common.ows_reslim_cfg import reslim_continental, reslim_lowres
+from ows_refactored.common.ows_reslim_cfg import reslim_geomad, reslim_lowres
 from ows_refactored.surface_reflectance.band_sr_cfg import bands_ls8_ls9_gm
 from ows_refactored.surface_reflectance.style_sr_cfg import styles_gm_ls5789_list
 
@@ -37,7 +37,7 @@ For more information on the algorithm, see https://doi.org/10.1109/TGRS.2017.272
     "low_res_product_name": "gm_ls8_ls9_annual_lowres",
     "bands": bands_ls8_ls9_gm,
     "dynamic": False,
-    "resource_limits": reslim_continental,
+    "resource_limits": reslim_geomad,
     "time_resolution": "year",
     "image_processing": {
         "extent_mask_func": "ows_refactored.common.ows_util_tools.mask_by_emad_nan",

--- a/services/ows_refactored/surface_reflectance/ows_gm_s2_annual_cfg.py
+++ b/services/ows_refactored/surface_reflectance/ows_gm_s2_annual_cfg.py
@@ -1,4 +1,4 @@
-from ows_refactored.common.ows_reslim_cfg import reslim_smart5, reslim_lowres
+from ows_refactored.common.ows_reslim_cfg import reslim_geomad, reslim_lowres
 from ows_refactored.surface_reflectance.band_sr_cfg import bands_s2_gm
 from ows_refactored.surface_reflectance.style_sr_cfg import styles_gm_list
 
@@ -37,7 +37,7 @@ For more information on the algorithm, see https://doi.org/10.1109/TGRS.2017.272
     "low_res_product_name": "gm_s2_annual_lowres",
     "bands": bands_s2_gm,
     "dynamic": False,
-    "resource_limits": reslim_smart5,
+    "resource_limits": reslim_geomad,
     "time_resolution": "year",
     "image_processing": {
         "extent_mask_func": "ows_refactored.common.ows_util_tools.mask_by_emad_nan",

--- a/services/ows_refactored/surface_reflectance/ows_gm_s2_semiannual_cfg.py
+++ b/services/ows_refactored/surface_reflectance/ows_gm_s2_semiannual_cfg.py
@@ -1,4 +1,4 @@
-from ows_refactored.common.ows_reslim_cfg import reslim_smart5, reslim_lowres
+from ows_refactored.common.ows_reslim_cfg import reslim_geomad, reslim_lowres
 from ows_refactored.surface_reflectance.band_sr_cfg import bands_s2_gm
 from ows_refactored.surface_reflectance.style_sr_cfg import styles_gm_list
 
@@ -35,7 +35,7 @@ For more information on the algorithm, see https://doi.org/10.1109/TGRS.2017.272
     "low_res_product_name": "gm_s2_semiannual_lowres",
     "bands": bands_s2_gm,
     "dynamic": False,
-    "resource_limits": reslim_smart5,
+    "resource_limits": reslim_geomad,
     "time_resolution": "summary",
     "image_processing": {
         "extent_mask_func": "ows_refactored.common.ows_util_tools.mask_by_emad_nan",


### PR DESCRIPTION
#  Fix GeoMAD continental 504: working min_zoom_factor on geomedian layers" \

  ## Problem
  All GeoMAD layers 504 at continental zoom: OWS ran full-res continental renders
  (60–115s) past gunicorn's 121s timeout → WORKER TIMEOUT → 504. 
<img width="2553" height="1433" alt="20260615_14h23m55s_grim" src="https://github.com/user-attachments/assets/92cc57e2-3d00-4cdb-85e9-b1c334acd9fe" />


  ## Cause
  The `low_res_product_name` swap only fires when a request exceeds the parent's
  `resource_limits` (`zoom_factor < min_zoom_factor`). The S2 geomedians used
  `reslim_smart5`, which sets `min_zoom_level` — valid in datacube-ows 1.9.x but
  **ignored on the deployed 1.8.42** (only `min_zoom_factor` exists). Landsat used
  `reslim_continental` (10.0), too low: the timing-out tiles sit at zoom_factor ~12–23.

  ## Fix
  New `reslim_geomad` profile (`min_zoom_factor: 30.0`); point all five low_res-backed
  geomedians at it (gm_s2_annual, gm_s2_semiannual, gm_ls5_ls7_annual, gm_ls8_annual,
  gm_ls8_ls9_annual). `reslim_smart5`/`reslim_continental` left untouched (other layers).

  ## Verify after deploy
  Continental `gm_s2_annual` drops from 60–115s to sub-second, no WORKER TIMEOUT;
  map shows lowres mosaic. Test each layer at a year it covers (ls8_ls9 ≥2021,
  ls8 ≥2013, ls5_ls7 ≤2012).