### PR TITLE
Add CRS and resolution to s1_monthly_mosaic for ODC storage

### DIFF
--- a/products/s1-monthly-mosaic.odc-product.yaml
+++ b/products/s1-monthly-mosaic.odc-product.yaml
@@ -9,6 +9,12 @@ metadata:
   product:
     name: s1_monthly_mosaic
 
+storage:
+  crs: EPSG:4326
+  resolution:
+    longitude: 0.0002
+    latitude: -0.0002
+
 measurements:
   - name: "VV"
     aliases: [vv]


### PR DESCRIPTION
This change is necessary to bring the `s1_monthly_mosaic` product in line with other products that have a default CRS and resolution, without which [`dc.load()`](https://opendatacube.readthedocs.io/en/latest/api/core-classes/datacube.html#datacube.Datacube.load) asks for an explicit CRS and resolution, adding an extra step to load the product if the user does not want to change the default CRS or resolution.

The resolution and CRS specificied in this PR are kept the same as the [`s1_rtc`](https://explorer.digitalearth.africa/products/s1_rtc) product. It has been validated that the resolution of the collection is 20m through the [SentinelHub webpage](https://custom-scripts.sentinel-hub.com/custom-scripts/sentinel/sentinel1-monthly-mosaic/).